### PR TITLE
feat: milestone Install UX — plugin VibeFlow + skill /vibeflow-install à toggles

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "vibeflow-os",
+  "description": "Marketplace officiel de VibeFlow : orchestrateur de développement Claude Code à modules toggables.",
+  "owner": {
+    "name": "picmakpro"
+  },
+  "plugins": [
+    {
+      "name": "vibeflow",
+      "description": "Orchestrateur de développement Claude Code : modules toggables (dev, audit, validator…) + engine d'install scopé, posés via une UX à toggles.",
+      "version": "2.3.0",
+      "source": "./",
+      "category": "development",
+      "homepage": "https://github.com/picmakpro/vibeflow-os",
+      "author": {
+        "name": "picmakpro"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "vibeflow",
+  "displayName": "VibeFlow",
+  "version": "2.3.0",
+  "description": "Orchestrateur de développement Claude Code : modules toggables (dev, audit, validator…) + engine d'install scopé, posés via une UX à toggles.",
+  "author": {
+    "name": "picmakpro"
+  },
+  "homepage": "https://github.com/picmakpro/vibeflow-os",
+  "repository": "https://github.com/picmakpro/vibeflow-os",
+  "license": "UNLICENSED",
+  "keywords": [
+    "vibeflow",
+    "gsd",
+    "orchestrator",
+    "modules",
+    "install",
+    "claude-code"
+  ],
+  "skills": "./installer",
+  "hooks": "./installer/hooks/hooks.json"
+}

--- a/.planning/BACKLOG.md
+++ b/.planning/BACKLOG.md
@@ -1,0 +1,15 @@
+# Backlog — idées différées (hors milestone courant)
+
+## Skill-installer global (multi-agents)
+**Capturé :** 2026-06-04 · **À explorer :** après le milestone « Install UX »
+
+Étendre l'approche d'install à toggles (plugin + skill `/vibeflow-install`) à l'**installation
+de skills globaux disponibles pour tous les agents** — un « skill-installer » générique :
+choisir des skills (pas seulement des modules VibeFlow) et les rendre disponibles globalement à
+l'ensemble des agents, via la même UX à toggles + scope.
+
+**Pourquoi différé :** chantier distinct du milestone Install UX (qui cible la distribution des
+modules VibeFlow). À reprendre une fois l'engine scope-aware + le skill `/vibeflow-install` livrés
+(ils en seront la fondation réutilisable).
+
+**Déclencheur de resurgence :** clôture du milestone « Install UX ».

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -45,10 +45,10 @@
 
 ### Engine scope-aware (Phase 3)
 
-- [ ] **SCOPE-01**: `vibeflow-update.sh` accepte `--scope user|project|local` → résout `TARGET_ROOT` (`~/.claude` vs `./.claude`).
-- [ ] **SCOPE-02**: Source des modules = cache du plugin (plus de `git clone .vibeflow-cache`).
+- [x] **SCOPE-01**: `vibeflow-update.sh` accepte `--scope user|project|local` → résout `TARGET_ROOT` (`~/.claude` vs `./.claude`).
+- [x] **SCOPE-02**: Source des modules = cache du plugin (plus de `git clone .vibeflow-cache`).
 - [ ] **SCOPE-03**: `ensure-deps.sh` scopé : GSD `--global`/`--local`, Superpowers `--scope user|project|local`.
-- [ ] **SCOPE-04**: Scope `local` → ajout des chemins installés au `.gitignore`.
+- [x] **SCOPE-04**: Scope `local` → ajout des chemins installés au `.gitignore`.
 
 ### Skill /vibeflow-install + auto-lancement (Phase 4)
 
@@ -105,10 +105,10 @@
 | VERIF-02 | Phase 1 | Complete |
 | MANIF-01 | Phase 2 | Complete |
 | MANIF-02 | Phase 2 | Complete |
-| SCOPE-01 | Phase 3 | Pending |
-| SCOPE-02 | Phase 3 | Pending |
+| SCOPE-01 | Phase 3 | Complete |
+| SCOPE-02 | Phase 3 | Complete |
 | SCOPE-03 | Phase 3 | Pending |
-| SCOPE-04 | Phase 3 | Pending |
+| SCOPE-04 | Phase 3 | Complete |
 | INST-01 | Phase 4 | Pending |
 | INST-02 | Phase 4 | Pending |
 | INST-03 | Phase 4 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -41,7 +41,7 @@
 ### Manifeste & résolveur (Phase 2)
 
 - [x] **MANIF-01**: Chaque module a un `module.json` (name, version, type, description, `requires[]`) — source machine-lisible.
-- [ ] **MANIF-02**: Un résolveur calcule la fermeture transitive des `requires` (ex. validator → consolidator + infrastructure-audit).
+- [x] **MANIF-02**: Un résolveur calcule la fermeture transitive des `requires` (ex. validator → consolidator + infrastructure-audit).
 
 ### Engine scope-aware (Phase 3)
 
@@ -104,7 +104,7 @@
 | VERIF-01 | Phase 1 | Complete |
 | VERIF-02 | Phase 1 | Complete |
 | MANIF-01 | Phase 2 | Complete |
-| MANIF-02 | Phase 2 | Pending |
+| MANIF-02 | Phase 2 | Complete |
 | SCOPE-01 | Phase 3 | Pending |
 | SCOPE-02 | Phase 3 | Pending |
 | SCOPE-03 | Phase 3 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -60,8 +60,8 @@
 
 ### Packaging plugin (Phase 5)
 
-- [ ] **PLUG-01**: `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` valides.
-- [ ] **PLUG-02**: Le plugin bundle modules + skill + engine + manifeste.
+- [x] **PLUG-01**: `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` valides.
+- [x] **PLUG-02**: Le plugin bundle modules + skill + engine + manifeste.
 - [ ] **PLUG-03**: Repo `vibeflow-os` rendu public (étape délibérée confirmée).
 - [ ] **PLUG-04**: `claude plugin marketplace add` + `install` fonctionnent en zéro-auth (validé).
 
@@ -114,8 +114,8 @@
 | INST-03 | Phase 4 | Complete |
 | INST-04 | Phase 4 | Complete |
 | INST-05 | Phase 4 | Complete |
-| PLUG-01 | Phase 5 | Pending |
-| PLUG-02 | Phase 5 | Pending |
+| PLUG-01 | Phase 5 | Complete |
+| PLUG-02 | Phase 5 | Complete |
 | PLUG-03 | Phase 5 | Pending |
 | PLUG-04 | Phase 5 | Pending |
 | FIRST-01 | Phase 6 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -67,8 +67,8 @@
 
 ### dev-orchestrator first-use (Phase 6)
 
-- [ ] **FIRST-01**: L'agent détecte l'absence de `.planning/` (projet non GSD-initialisé) au 1er usage.
-- [ ] **FIRST-02**: Il propose map-codebase puis new-project sur confirmation (jamais `gsd-new-project` seul).
+- [x] **FIRST-01**: L'agent détecte l'absence de `.planning/` (projet non GSD-initialisé) au 1er usage.
+- [x] **FIRST-02**: Il propose map-codebase puis new-project sur confirmation (jamais `gsd-new-project` seul).
 
 ## v2 Requirements
 
@@ -118,8 +118,8 @@
 | PLUG-02 | Phase 5 | Complete |
 | PLUG-03 | Phase 5 | Pending |
 | PLUG-04 | Phase 5 | Pending |
-| FIRST-01 | Phase 6 | Pending |
-| FIRST-02 | Phase 6 | Pending |
+| FIRST-01 | Phase 6 | Complete |
+| FIRST-02 | Phase 6 | Complete |
 
 **Coverage:**
 - Milestone 1 (v1) : 14 requirements — Complete ✓

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -56,7 +56,7 @@
 - [x] **INST-02**: Toggle modules (multi-select) avec description issue des `module.json`.
 - [x] **INST-03**: Récap des dépendances auto-résolues avant install.
 - [x] **INST-04**: Orchestration de l'install au scope choisi (modules + GSD + Superpowers).
-- [ ] **INST-05**: Hook `SessionStart` + marqueur de 1er lancement → ouvre l'UX automatiquement (ID8).
+- [x] **INST-05**: Hook `SessionStart` + marqueur de 1er lancement → ouvre l'UX automatiquement (ID8).
 
 ### Packaging plugin (Phase 5)
 
@@ -113,7 +113,7 @@
 | INST-02 | Phase 4 | Complete |
 | INST-03 | Phase 4 | Complete |
 | INST-04 | Phase 4 | Complete |
-| INST-05 | Phase 4 | Pending |
+| INST-05 | Phase 4 | Complete |
 | PLUG-01 | Phase 5 | Pending |
 | PLUG-02 | Phase 5 | Pending |
 | PLUG-03 | Phase 5 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -52,10 +52,10 @@
 
 ### Skill /vibeflow-install + auto-lancement (Phase 4)
 
-- [ ] **INST-01**: Toggle scope (single-select user/project/local).
-- [ ] **INST-02**: Toggle modules (multi-select) avec description issue des `module.json`.
-- [ ] **INST-03**: Récap des dépendances auto-résolues avant install.
-- [ ] **INST-04**: Orchestration de l'install au scope choisi (modules + GSD + Superpowers).
+- [x] **INST-01**: Toggle scope (single-select user/project/local).
+- [x] **INST-02**: Toggle modules (multi-select) avec description issue des `module.json`.
+- [x] **INST-03**: Récap des dépendances auto-résolues avant install.
+- [x] **INST-04**: Orchestration de l'install au scope choisi (modules + GSD + Superpowers).
 - [ ] **INST-05**: Hook `SessionStart` + marqueur de 1er lancement → ouvre l'UX automatiquement (ID8).
 
 ### Packaging plugin (Phase 5)
@@ -109,10 +109,10 @@
 | SCOPE-02 | Phase 3 | Complete |
 | SCOPE-03 | Phase 3 | Complete |
 | SCOPE-04 | Phase 3 | Complete |
-| INST-01 | Phase 4 | Pending |
-| INST-02 | Phase 4 | Pending |
-| INST-03 | Phase 4 | Pending |
-| INST-04 | Phase 4 | Pending |
+| INST-01 | Phase 4 | Complete |
+| INST-02 | Phase 4 | Complete |
+| INST-03 | Phase 4 | Complete |
+| INST-04 | Phase 4 | Complete |
 | INST-05 | Phase 4 | Pending |
 | PLUG-01 | Phase 5 | Pending |
 | PLUG-02 | Phase 5 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -40,7 +40,7 @@
 
 ### Manifeste & résolveur (Phase 2)
 
-- [ ] **MANIF-01**: Chaque module a un `module.json` (name, version, type, description, `requires[]`) — source machine-lisible.
+- [x] **MANIF-01**: Chaque module a un `module.json` (name, version, type, description, `requires[]`) — source machine-lisible.
 - [ ] **MANIF-02**: Un résolveur calcule la fermeture transitive des `requires` (ex. validator → consolidator + infrastructure-audit).
 
 ### Engine scope-aware (Phase 3)
@@ -103,7 +103,7 @@
 | BOOT-04 | Phase 1 | Complete |
 | VERIF-01 | Phase 1 | Complete |
 | VERIF-02 | Phase 1 | Complete |
-| MANIF-01 | Phase 2 | Pending |
+| MANIF-01 | Phase 2 | Complete |
 | MANIF-02 | Phase 2 | Pending |
 | SCOPE-01 | Phase 3 | Pending |
 | SCOPE-02 | Phase 3 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -34,6 +34,42 @@
 - [x] **VERIF-01**: `tests/test-dev-orchestrator.sh` couvre génération d'index, idempotence de `ensure-deps`, couverture du routage, mapping `/vf-*` non orphelin.
 - [x] **VERIF-02**: Gates de densité respectés (agent ≤250L, skills ≤500L), vérifiés par `wc -l` dans le test du module (`check-file-size.sh` n'audite pas les `.md` : regex code sans `.md`).
 
+## Milestone 2 — Install UX (active)
+
+> Spec : `docs/superpowers/specs/2026-06-04-install-ux-design.md`
+
+### Manifeste & résolveur (Phase 2)
+
+- [ ] **MANIF-01**: Chaque module a un `module.json` (name, version, type, description, `requires[]`) — source machine-lisible.
+- [ ] **MANIF-02**: Un résolveur calcule la fermeture transitive des `requires` (ex. validator → consolidator + infrastructure-audit).
+
+### Engine scope-aware (Phase 3)
+
+- [ ] **SCOPE-01**: `vibeflow-update.sh` accepte `--scope user|project|local` → résout `TARGET_ROOT` (`~/.claude` vs `./.claude`).
+- [ ] **SCOPE-02**: Source des modules = cache du plugin (plus de `git clone .vibeflow-cache`).
+- [ ] **SCOPE-03**: `ensure-deps.sh` scopé : GSD `--global`/`--local`, Superpowers `--scope user|project|local`.
+- [ ] **SCOPE-04**: Scope `local` → ajout des chemins installés au `.gitignore`.
+
+### Skill /vibeflow-install + auto-lancement (Phase 4)
+
+- [ ] **INST-01**: Toggle scope (single-select user/project/local).
+- [ ] **INST-02**: Toggle modules (multi-select) avec description issue des `module.json`.
+- [ ] **INST-03**: Récap des dépendances auto-résolues avant install.
+- [ ] **INST-04**: Orchestration de l'install au scope choisi (modules + GSD + Superpowers).
+- [ ] **INST-05**: Hook `SessionStart` + marqueur de 1er lancement → ouvre l'UX automatiquement (ID8).
+
+### Packaging plugin (Phase 5)
+
+- [ ] **PLUG-01**: `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` valides.
+- [ ] **PLUG-02**: Le plugin bundle modules + skill + engine + manifeste.
+- [ ] **PLUG-03**: Repo `vibeflow-os` rendu public (étape délibérée confirmée).
+- [ ] **PLUG-04**: `claude plugin marketplace add` + `install` fonctionnent en zéro-auth (validé).
+
+### dev-orchestrator first-use (Phase 6)
+
+- [ ] **FIRST-01**: L'agent détecte l'absence de `.planning/` (projet non GSD-initialisé) au 1er usage.
+- [ ] **FIRST-02**: Il propose map-codebase puis new-project sur confirmation (jamais `gsd-new-project` seul).
+
 ## v2 Requirements
 
 ### Vocabulaire & UX
@@ -67,11 +103,27 @@
 | BOOT-04 | Phase 1 | Complete |
 | VERIF-01 | Phase 1 | Complete |
 | VERIF-02 | Phase 1 | Complete |
+| MANIF-01 | Phase 2 | Pending |
+| MANIF-02 | Phase 2 | Pending |
+| SCOPE-01 | Phase 3 | Pending |
+| SCOPE-02 | Phase 3 | Pending |
+| SCOPE-03 | Phase 3 | Pending |
+| SCOPE-04 | Phase 3 | Pending |
+| INST-01 | Phase 4 | Pending |
+| INST-02 | Phase 4 | Pending |
+| INST-03 | Phase 4 | Pending |
+| INST-04 | Phase 4 | Pending |
+| INST-05 | Phase 4 | Pending |
+| PLUG-01 | Phase 5 | Pending |
+| PLUG-02 | Phase 5 | Pending |
+| PLUG-03 | Phase 5 | Pending |
+| PLUG-04 | Phase 5 | Pending |
+| FIRST-01 | Phase 6 | Pending |
+| FIRST-02 | Phase 6 | Pending |
 
 **Coverage:**
-- v1 requirements: 14 total
-- Mapped to phases: 14
-- Unmapped: 0 ✓
+- Milestone 1 (v1) : 14 requirements — Complete ✓
+- Milestone 2 (Install UX) : 17 requirements — mappés aux phases 2-6, 0 non-mappé ✓
 
 ---
 *Requirements defined: 2026-06-04*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -47,7 +47,7 @@
 
 - [x] **SCOPE-01**: `vibeflow-update.sh` accepte `--scope user|project|local` → résout `TARGET_ROOT` (`~/.claude` vs `./.claude`).
 - [x] **SCOPE-02**: Source des modules = cache du plugin (plus de `git clone .vibeflow-cache`).
-- [ ] **SCOPE-03**: `ensure-deps.sh` scopé : GSD `--global`/`--local`, Superpowers `--scope user|project|local`.
+- [x] **SCOPE-03**: `ensure-deps.sh` scopé : GSD `--global`/`--local`, Superpowers `--scope user|project|local`.
 - [x] **SCOPE-04**: Scope `local` → ajout des chemins installés au `.gitignore`.
 
 ### Skill /vibeflow-install + auto-lancement (Phase 4)
@@ -107,7 +107,7 @@
 | MANIF-02 | Phase 2 | Complete |
 | SCOPE-01 | Phase 3 | Complete |
 | SCOPE-02 | Phase 3 | Complete |
-| SCOPE-03 | Phase 3 | Pending |
+| SCOPE-03 | Phase 3 | Complete |
 | SCOPE-04 | Phase 3 | Complete |
 | INST-01 | Phase 4 | Pending |
 | INST-02 | Phase 4 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -59,7 +59,7 @@ Plans:
   4. Un hook `SessionStart` ouvre l'UX automatiquement au 1er lancement (marqueur).
 **Plans**: 2 plans (1 wave — parallèles, fichiers disjoints)
 Plans:
-- [ ] 04-01-PLAN.md — catalogue modules `build-module-catalog.sh` + skill `/vibeflow-install` (toggles scope+modules, récap déps, orchestration scope-aware) + test (INST-01..04)
+- [x] 04-01-PLAN.md — catalogue modules `build-module-catalog.sh` + skill `/vibeflow-install` (toggles scope+modules, récap déps, orchestration scope-aware) + test (INST-01..04)
 - [ ] 04-02-PLAN.md — hook `SessionStart` + marqueur de 1er lancement (modèle Superpowers) + test isolé (INST-05)
 
 #### Phase 5: Packaging plugin

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -46,7 +46,7 @@ Plans:
 **Plans**: 2 plans (1 wave — parallèles, fichiers disjoints)
 Plans:
 - [x] 03-01-PLAN.md — vibeflow-update.sh scope-aware : TARGET_ROOT + suppression clone + gitignore local + résolveur câblé + test isolé (SCOPE-01, SCOPE-02, SCOPE-04)
-- [ ] 03-02-PLAN.md — ensure-deps.sh scopé (GSD --global/--local, Superpowers --scope) + test 3 scopes en dry-run (SCOPE-03)
+- [x] 03-02-PLAN.md — ensure-deps.sh scopé (GSD --global/--local, Superpowers --scope) + test 3 scopes en dry-run (SCOPE-03)
 
 #### Phase 4: Skill /vibeflow-install + auto-lancement
 **Goal**: Le skill interactif (toggles scope + modules, récap déps, orchestration) + auto-lancement au 1er démarrage.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -32,7 +32,7 @@ Spec : `docs/superpowers/specs/2026-06-04-install-ux-design.md`.
   2. Le résolveur, donné une sélection, retourne la fermeture transitive correcte (validator → +consolidator +infrastructure-audit).
 **Plans**: 2 plans (2 waves)
 Plans:
-- [ ] 02-01-PLAN.md — 8 module.json (name, version, type, description, requires) pour les 8 modules (MANIF-01)
+- [x] 02-01-PLAN.md — 8 module.json (name, version, type, description, requires) pour les 8 modules (MANIF-01)
 - [ ] 02-02-PLAN.md — résolveur de fermeture transitive `_internal/resolve-deps.sh` + test (MANIF-02)
 
 #### Phase 3: Engine scope-aware

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -81,7 +81,9 @@ Plans:
 **Success Criteria** (what must be TRUE):
   1. L'agent détecte l'absence de `.planning/` au premier usage.
   2. Il propose map-codebase puis new-project sur confirmation (jamais `gsd-new-project` seul).
-**Plans**: TBD
+**Plans**: 1 plan (1 wave)
+Plans:
+- [ ] 06-01-PLAN.md — garde-fou first-use dans AGENT.md (détection `.planning/PROJECT.md` absent → délégation vf-init, new-project jamais seul) + axe de test T7 (FIRST-01, FIRST-02)
 
 ## Progress
 
@@ -95,4 +97,4 @@ Plans:
 | 3. Engine scope-aware | Install UX | 0/2 | Not started | - |
 | 4. Skill /vibeflow-install | Install UX | 0/2 | Not started | - |
 | 5. Packaging plugin | Install UX | 0/2 | Planned | - |
-| 6. dev-orchestrator first-use | Install UX | 0/TBD | Not started | - |
+| 6. dev-orchestrator first-use | Install UX | 0/1 | Planned | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -71,7 +71,7 @@ Plans:
   2. `claude plugin marketplace add picmakpro/vibeflow-os` + `install vibeflow` fonctionnent en zéro-auth (repo public).
 **Plans**: 2 plans (2 waves — Plan 02 CONFIRMATION-GATED / non-autonome)
 Plans:
-- [ ] 05-01-PLAN.md — `.claude-plugin/plugin.json` + `marketplace.json` (calque Superpowers) + câblage VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} dans le skill + doc d'install 2-commandes (PLUG-01, PLUG-02)
+- [x] 05-01-PLAN.md — `.claude-plugin/plugin.json` + `marketplace.json` (calque Superpowers) + câblage VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} dans le skill + doc d'install 2-commandes (PLUG-01, PLUG-02)
 - [ ] 05-02-PLAN.md — checklist pré-public + flip repo public + validation marketplace add/install zéro-auth — CONFIRMÉ HORS-AGENT (PLUG-03, PLUG-04)
 
 #### Phase 6: dev-orchestrator first-use

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -45,7 +45,7 @@ Plans:
   3. `ensure-deps.sh` installe GSD + Superpowers au scope demandé.
 **Plans**: 2 plans (1 wave — parallèles, fichiers disjoints)
 Plans:
-- [ ] 03-01-PLAN.md — vibeflow-update.sh scope-aware : TARGET_ROOT + suppression clone + gitignore local + résolveur câblé + test isolé (SCOPE-01, SCOPE-02, SCOPE-04)
+- [x] 03-01-PLAN.md — vibeflow-update.sh scope-aware : TARGET_ROOT + suppression clone + gitignore local + résolveur câblé + test isolé (SCOPE-01, SCOPE-02, SCOPE-04)
 - [ ] 03-02-PLAN.md — ensure-deps.sh scopé (GSD --global/--local, Superpowers --scope) + test 3 scopes en dry-run (SCOPE-03)
 
 #### Phase 4: Skill /vibeflow-install + auto-lancement

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -83,7 +83,7 @@ Plans:
   2. Il propose map-codebase puis new-project sur confirmation (jamais `gsd-new-project` seul).
 **Plans**: 1 plan (1 wave)
 Plans:
-- [ ] 06-01-PLAN.md — garde-fou first-use dans AGENT.md (détection `.planning/PROJECT.md` absent → délégation vf-init, new-project jamais seul) + axe de test T7 (FIRST-01, FIRST-02)
+- [x] 06-01-PLAN.md — garde-fou first-use dans AGENT.md (détection `.planning/PROJECT.md` absent → délégation vf-init, new-project jamais seul) + axe de test T7 (FIRST-01, FIRST-02)
 
 ## Progress
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -60,7 +60,7 @@ Plans:
 **Plans**: 2 plans (1 wave — parallèles, fichiers disjoints)
 Plans:
 - [x] 04-01-PLAN.md — catalogue modules `build-module-catalog.sh` + skill `/vibeflow-install` (toggles scope+modules, récap déps, orchestration scope-aware) + test (INST-01..04)
-- [ ] 04-02-PLAN.md — hook `SessionStart` + marqueur de 1er lancement (modèle Superpowers) + test isolé (INST-05)
+- [x] 04-02-PLAN.md — hook `SessionStart` + marqueur de 1er lancement (modèle Superpowers) + test isolé (INST-05)
 
 #### Phase 5: Packaging plugin
 **Goal**: VibeFlow installable comme plugin Claude Code (marketplace), repo public.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -57,7 +57,10 @@ Plans:
   2. Les dépendances sont auto-résolues et récapitulées avant install.
   3. L'install s'effectue au scope choisi (modules + GSD + Superpowers).
   4. Un hook `SessionStart` ouvre l'UX automatiquement au 1er lancement (marqueur).
-**Plans**: TBD
+**Plans**: 2 plans (1 wave — parallèles, fichiers disjoints)
+Plans:
+- [ ] 04-01-PLAN.md — catalogue modules `build-module-catalog.sh` + skill `/vibeflow-install` (toggles scope+modules, récap déps, orchestration scope-aware) + test (INST-01..04)
+- [ ] 04-02-PLAN.md — hook `SessionStart` + marqueur de 1er lancement (modèle Superpowers) + test isolé (INST-05)
 
 #### Phase 5: Packaging plugin
 **Goal**: VibeFlow installable comme plugin Claude Code (marketplace), repo public.
@@ -87,6 +90,6 @@ Plans:
 | 1. dev-orchestrator | vfdo-v1.0 | 5/5 | Complete | 2026-06-04 |
 | 2. Manifeste & résolveur | Install UX | 2/2 | Complete | 2026-06-04 |
 | 3. Engine scope-aware | Install UX | 0/2 | Not started | - |
-| 4. Skill /vibeflow-install | Install UX | 0/TBD | Not started | - |
+| 4. Skill /vibeflow-install | Install UX | 0/2 | Not started | - |
 | 5. Packaging plugin | Install UX | 0/TBD | Not started | - |
 | 6. dev-orchestrator first-use | Install UX | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -30,7 +30,10 @@ Spec : `docs/superpowers/specs/2026-06-04-install-ux-design.md`.
 **Success Criteria** (what must be TRUE):
   1. Les 8 modules ont un `module.json` valide (name, version, type, description, `requires[]`).
   2. Le résolveur, donné une sélection, retourne la fermeture transitive correcte (validator → +consolidator +infrastructure-audit).
-**Plans**: TBD (raffiné en plan-phase)
+**Plans**: 2 plans (2 waves)
+Plans:
+- [ ] 02-01-PLAN.md — 8 module.json (name, version, type, description, requires) pour les 8 modules (MANIF-01)
+- [ ] 02-02-PLAN.md — résolveur de fermeture transitive `_internal/resolve-deps.sh` + test (MANIF-02)
 
 #### Phase 3: Engine scope-aware
 **Goal**: `vibeflow-update.sh` + `ensure-deps.sh` installent au scope choisi, depuis le cache du plugin.
@@ -79,7 +82,7 @@ Spec : `docs/superpowers/specs/2026-06-04-install-ux-design.md`.
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
 | 1. dev-orchestrator | vfdo-v1.0 | 5/5 | Complete | 2026-06-04 |
-| 2. Manifeste & résolveur | Install UX | 0/TBD | Not started | - |
+| 2. Manifeste & résolveur | Install UX | 0/2 | Planned | - |
 | 3. Engine scope-aware | Install UX | 0/TBD | Not started | - |
 | 4. Skill /vibeflow-install | Install UX | 0/TBD | Not started | - |
 | 5. Packaging plugin | Install UX | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -33,7 +33,7 @@ Spec : `docs/superpowers/specs/2026-06-04-install-ux-design.md`.
 **Plans**: 2 plans (2 waves)
 Plans:
 - [x] 02-01-PLAN.md — 8 module.json (name, version, type, description, requires) pour les 8 modules (MANIF-01)
-- [ ] 02-02-PLAN.md — résolveur de fermeture transitive `_internal/resolve-deps.sh` + test (MANIF-02)
+- [x] 02-02-PLAN.md — résolveur de fermeture transitive `_internal/resolve-deps.sh` + test (MANIF-02)
 
 #### Phase 3: Engine scope-aware
 **Goal**: `vibeflow-update.sh` + `ensure-deps.sh` installent au scope choisi, depuis le cache du plugin.
@@ -82,7 +82,7 @@ Plans:
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
 | 1. dev-orchestrator | vfdo-v1.0 | 5/5 | Complete | 2026-06-04 |
-| 2. Manifeste & résolveur | Install UX | 0/2 | Planned | - |
+| 2. Manifeste & résolveur | Install UX | 2/2 | Complete | 2026-06-04 |
 | 3. Engine scope-aware | Install UX | 0/TBD | Not started | - |
 | 4. Skill /vibeflow-install | Install UX | 0/TBD | Not started | - |
 | 5. Packaging plugin | Install UX | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,46 +1,86 @@
 # Roadmap: VibeFlow Dev Orchestrator (VFDO)
 
-## Overview
+## Milestones
 
-Une seule phase livre le module `dev-orchestrator/` complet : le bootstrap d'auto-install,
-l'index GSD auto-généré, l'agent routeur, la couche d'abstraction `/vf-*`, et la vérification.
-Le module est ensuite branchable sur n'importe quel lab via `vibeflow-update.sh`.
+- ✅ **vfdo-v1.0** — Module dev-orchestrator (Phase 1) — clôturé 2026-06-04
+- 🚧 **Install UX** — Phases 2-6 (en cours) — install plugin + skill à toggles + scope
 
 ## Phases
 
-- [x] **Phase 1: dev-orchestrator** - Module complet VibeFlow → GSD + Superpowers (agent routeur, index auto, verbes `/vf-*`, bootstrap auto-install)
-
-## Phase Details
+<details>
+<summary>✅ vfdo-v1.0 — Module dev-orchestrator (Phase 1) — SHIPPED 2026-06-04</summary>
 
 ### Phase 1: dev-orchestrator
-**Goal**: Livrer le module `dev-orchestrator/` distribuable, qui rend GSD + Superpowers invisibles et auto-installés derrière un agent VibeFlow.
-**Depends on**: Nothing (first phase)
-**Requirements**: ROUT-01, ROUT-02, ROUT-03, ROUT-04, IDX-01, IDX-02, ABS-01, ABS-02, BOOT-01, BOOT-02, BOOT-03, BOOT-04, VERIF-01, VERIF-02
-**Success Criteria** (what must be TRUE):
-  1. Sur une machine sans GSD ni Superpowers, brancher le module les installe automatiquement (ou affiche les étapes manuelles si Node/`claude` manquent).
-  2. L'utilisateur formule une demande dev en langage naturel et l'agent lance le bon skill GSD/superpowers sans jamais nommer « GSD ».
-  3. `references/gsd-skills-index.md` est généré depuis les skills GSD réellement installés (aucun nom inventé) et se régénère sur update.
-  4. Les verbes `/vf-*` existent, mappent vers une cible réelle, et sont invocables par l'agent en autonomie (dont `gsd-autonomous`).
-  5. `test-dev-orchestrator.sh` passe à 100% et les gates de densité (agent ≤250L, skills ≤500L) sont verts.
-**Plans**: 5 plans en 4 waves
+**Goal**: Module `dev-orchestrator/` distribuable (agent routeur, index auto, verbes `/vf-*`, bootstrap auto-install).
+**Plans**: 5 plans (4 waves) — tous complétés.
+Snapshots : `.planning/milestones/vfdo-v1.0-*`. Détails : `MILESTONES.md`.
 
-Plans:
-- [x] 01-01-PLAN.md — Scaffolding module + générateur d'index (`build-gsd-index.sh` → `gsd-skills-index.md`) [wave 1]
-- [x] 01-02-PLAN.md — Bootstrap auto-install (`ensure-deps.sh` + fallback manuel, BOOT-01..04) [wave 1]
-- [x] 01-03-PLAN.md — Agent `vibeflow-dev` (`AGENT.md`) + doctrine pipeline (`references/GSD-PIPELINE.md`, ROUT-01..04) [wave 2]
-- [x] 01-04-PLAN.md — Couche d'abstraction : 12 skills `/vf-*` + traduction de vocabulaire (ABS-01..02) [wave 3]
-- [x] 01-05-PLAN.md — Vérification (`tests/`) + intégration `vibeflow-update.sh` + README (VERIF-01..02) [wave 4]
+</details>
+
+### 🚧 Install UX (Phases 2-6)
+
+**Milestone Goal:** Réduire l'install de VibeFlow + modules à 2 commandes (plugin) + une UX à toggles
+qui se lance automatiquement, avec choix de scope (user/project/local) appliqué à tout (modules + GSD + Superpowers).
+Spec : `docs/superpowers/specs/2026-06-04-install-ux-design.md`.
+
+#### Phase 2: Manifeste & résolveur
+**Goal**: Doter chaque module d'un `module.json` machine-lisible + un résolveur de dépendances transitives.
+**Depends on**: Phase 1
+**Requirements**: MANIF-01, MANIF-02
+**Success Criteria** (what must be TRUE):
+  1. Les 8 modules ont un `module.json` valide (name, version, type, description, `requires[]`).
+  2. Le résolveur, donné une sélection, retourne la fermeture transitive correcte (validator → +consolidator +infrastructure-audit).
+**Plans**: TBD (raffiné en plan-phase)
+
+#### Phase 3: Engine scope-aware
+**Goal**: `vibeflow-update.sh` + `ensure-deps.sh` installent au scope choisi, depuis le cache du plugin.
+**Depends on**: Phase 2
+**Requirements**: SCOPE-01, SCOPE-02, SCOPE-03, SCOPE-04
+**Success Criteria** (what must be TRUE):
+  1. `--scope user` cible `~/.claude/` ; `project`/`local` cible `./.claude/` ; `local` ajoute au `.gitignore`.
+  2. Les modules sont installés depuis le cache du plugin (plus de `git clone`).
+  3. `ensure-deps.sh` installe GSD + Superpowers au scope demandé.
+**Plans**: TBD
+
+#### Phase 4: Skill /vibeflow-install + auto-lancement
+**Goal**: Le skill interactif (toggles scope + modules, récap déps, orchestration) + auto-lancement au 1er démarrage.
+**Depends on**: Phase 2, Phase 3
+**Requirements**: INST-01, INST-02, INST-03, INST-04, INST-05
+**Success Criteria** (what must be TRUE):
+  1. L'UX propose un toggle scope puis un toggle modules (depuis les `module.json`).
+  2. Les dépendances sont auto-résolues et récapitulées avant install.
+  3. L'install s'effectue au scope choisi (modules + GSD + Superpowers).
+  4. Un hook `SessionStart` ouvre l'UX automatiquement au 1er lancement (marqueur).
+**Plans**: TBD
+
+#### Phase 5: Packaging plugin
+**Goal**: VibeFlow installable comme plugin Claude Code (marketplace), repo public.
+**Depends on**: Phase 4
+**Requirements**: PLUG-01, PLUG-02, PLUG-03, PLUG-04
+**Success Criteria** (what must be TRUE):
+  1. `plugin.json` + `marketplace.json` valides ; le plugin bundle modules + skill + engine + manifeste.
+  2. `claude plugin marketplace add picmakpro/vibeflow-os` + `install vibeflow` fonctionnent en zéro-auth (repo public).
+**Plans**: TBD
+
+#### Phase 6: dev-orchestrator first-use
+**Goal**: Au 1er usage, l'agent détecte un projet non GSD-initialisé et propose l'init.
+**Depends on**: Phase 1 (indépendant des phases 2-5)
+**Requirements**: FIRST-01, FIRST-02
+**Success Criteria** (what must be TRUE):
+  1. L'agent détecte l'absence de `.planning/` au premier usage.
+  2. Il propose map-codebase puis new-project sur confirmation (jamais `gsd-new-project` seul).
+**Plans**: TBD
 
 ## Progress
 
 **Execution Order:**
-Phase unique : 1
-Waves : {01, 02} → {03} → {04} → {05}
+1 ✅ → 2 → 3 → 4 → 5 ; 6 indépendant (peut partir tôt)
 
-| Phase | Plans Complete | Status | Completed |
-|-------|----------------|--------|-----------|
-| 1. dev-orchestrator | 5/5 | Complete | 2026-06-04 |
-
----
-## Milestone vfdo-v1.0 — clôturé 2026-06-04
-Phase 1 (dev-orchestrator) livrée + incrément `vf-map` (v1.1.0). Snapshots archivés dans `.planning/milestones/`.
+| Phase | Milestone | Plans Complete | Status | Completed |
+|-------|-----------|----------------|--------|-----------|
+| 1. dev-orchestrator | vfdo-v1.0 | 5/5 | Complete | 2026-06-04 |
+| 2. Manifeste & résolveur | Install UX | 0/TBD | Not started | - |
+| 3. Engine scope-aware | Install UX | 0/TBD | Not started | - |
+| 4. Skill /vibeflow-install | Install UX | 0/TBD | Not started | - |
+| 5. Packaging plugin | Install UX | 0/TBD | Not started | - |
+| 6. dev-orchestrator first-use | Install UX | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -69,7 +69,10 @@ Plans:
 **Success Criteria** (what must be TRUE):
   1. `plugin.json` + `marketplace.json` valides ; le plugin bundle modules + skill + engine + manifeste.
   2. `claude plugin marketplace add picmakpro/vibeflow-os` + `install vibeflow` fonctionnent en zéro-auth (repo public).
-**Plans**: TBD
+**Plans**: 2 plans (2 waves — Plan 02 CONFIRMATION-GATED / non-autonome)
+Plans:
+- [ ] 05-01-PLAN.md — `.claude-plugin/plugin.json` + `marketplace.json` (calque Superpowers) + câblage VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} dans le skill + doc d'install 2-commandes (PLUG-01, PLUG-02)
+- [ ] 05-02-PLAN.md — checklist pré-public + flip repo public + validation marketplace add/install zéro-auth — CONFIRMÉ HORS-AGENT (PLUG-03, PLUG-04)
 
 #### Phase 6: dev-orchestrator first-use
 **Goal**: Au 1er usage, l'agent détecte un projet non GSD-initialisé et propose l'init.
@@ -91,5 +94,5 @@ Plans:
 | 2. Manifeste & résolveur | Install UX | 2/2 | Complete | 2026-06-04 |
 | 3. Engine scope-aware | Install UX | 0/2 | Not started | - |
 | 4. Skill /vibeflow-install | Install UX | 0/2 | Not started | - |
-| 5. Packaging plugin | Install UX | 0/TBD | Not started | - |
+| 5. Packaging plugin | Install UX | 0/2 | Planned | - |
 | 6. dev-orchestrator first-use | Install UX | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -43,7 +43,10 @@ Plans:
   1. `--scope user` cible `~/.claude/` ; `project`/`local` cible `./.claude/` ; `local` ajoute au `.gitignore`.
   2. Les modules sont installés depuis le cache du plugin (plus de `git clone`).
   3. `ensure-deps.sh` installe GSD + Superpowers au scope demandé.
-**Plans**: TBD
+**Plans**: 2 plans (1 wave — parallèles, fichiers disjoints)
+Plans:
+- [ ] 03-01-PLAN.md — vibeflow-update.sh scope-aware : TARGET_ROOT + suppression clone + gitignore local + résolveur câblé + test isolé (SCOPE-01, SCOPE-02, SCOPE-04)
+- [ ] 03-02-PLAN.md — ensure-deps.sh scopé (GSD --global/--local, Superpowers --scope) + test 3 scopes en dry-run (SCOPE-03)
 
 #### Phase 4: Skill /vibeflow-install + auto-lancement
 **Goal**: Le skill interactif (toggles scope + modules, récap déps, orchestration) + auto-lancement au 1er démarrage.
@@ -83,7 +86,7 @@ Plans:
 |-------|-----------|----------------|--------|-----------|
 | 1. dev-orchestrator | vfdo-v1.0 | 5/5 | Complete | 2026-06-04 |
 | 2. Manifeste & résolveur | Install UX | 2/2 | Complete | 2026-06-04 |
-| 3. Engine scope-aware | Install UX | 0/TBD | Not started | - |
+| 3. Engine scope-aware | Install UX | 0/2 | Not started | - |
 | 4. Skill /vibeflow-install | Install UX | 0/TBD | Not started | - |
 | 5. Packaging plugin | Install UX | 0/TBD | Not started | - |
 | 6. dev-orchestrator first-use | Install UX | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: install-ux
 milestone_name: Install UX
 status: verifying
 stopped_at: Completed 02-02-PLAN.md
-last_updated: "2026-06-04T18:18:45.956Z"
+last_updated: "2026-06-04T18:37:18.110Z"
 last_activity: 2026-06-04
 progress:
   total_phases: 5
-  completed_phases: 3
-  total_plans: 8
-  completed_plans: 7
-  percent: 88
+  completed_phases: 5
+  total_plans: 9
+  completed_plans: 9
+  percent: 100
 ---
 
 # Project State
@@ -30,7 +30,7 @@ Plan: 2 of 2 in current phase
 Status: Phase complete — ready for verification
 Last activity: 2026-06-04
 
-Progress: [█████████░] 88%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
@@ -57,6 +57,7 @@ Progress: [█████████░] 88%
 | Phase 04 P01 | ~1 min | 2 tasks | 3 files |
 | Phase 04 P02 | 5min | 2 tasks | 3 files |
 | Phase 05 P01 | 2 | 3 tasks | 5 files |
+| Phase 06 P01 | 1min | 2 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -78,6 +79,8 @@ Recent decisions affecting current work:
 - [Phase ?]: Plus de git clone/pull : source = cache local (require_cache) ; sync = no-op explicite
 - [Phase ?]: ensure-deps scope-aware via VF_SCOPE (GSD --global/--local, Superpowers --scope), VF_ENSURE_FORCE dry-run only, defaut LEGACY user (ID4)
 - [Phase ?]: Hook VibeFlow pointe directement le script bash; marqueur 1er lancement aligné sur registre engine scripts/.vibeflow-installed
+- [Phase 06]: Garde-fou first-use placé avant la table de routage (point de décision router-vs-proposer)
+- [Phase 06]: Séquence d'init non dupliquée : délégation au skill vf-init existant
 
 ### Pending Todos
 
@@ -95,6 +98,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-04T18:18:42.806Z
+Last session: 2026-06-04T18:36:28.459Z
 Stopped at: Completed 02-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,17 +1,17 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.0
-milestone_name: milestone
-status: verifying
-stopped_at: Scaffolding `.planning/` terminé, prêt pour plan-phase 1
-last_updated: "2026-06-04T14:58:23.299Z"
+milestone: install-ux
+milestone_name: Install UX
+status: planning
+stopped_at: Milestone Install UX scaffolté (phases 2-6), prêt pour plan-phase 2
+last_updated: "2026-06-04"
 last_activity: 2026-06-04
 progress:
-  total_phases: 1
+  total_phases: 6
   completed_phases: 1
   total_plans: 5
   completed_plans: 5
-  percent: 100
+  percent: 17
 ---
 
 # Project State
@@ -21,16 +21,16 @@ progress:
 See: .planning/PROJECT.md (updated 2026-06-04)
 
 **Core value:** Dire « aide-moi à dev » déclenche le pipeline GSD complet sans jamais connaître GSD/Superpowers.
-**Current focus:** Phase 1 — dev-orchestrator
+**Current focus:** Milestone Install UX — Phase 2 (Manifeste & résolveur)
 
 ## Current Position
 
-Phase: 1 of 1 (dev-orchestrator)
-Plan: 5 of 5 in current phase
-Status: Phase complete — ready for verification
-Last activity: 2026-06-04
+Phase: 2 of 6 (Manifeste & résolveur) — milestone Install UX
+Plan: 0 of TBD in current phase
+Status: Ready to plan
+Last activity: 2026-06-04 — Milestone Install UX scaffolté (ROADMAP/REQUIREMENTS depuis le spec)
 
-Progress: [██████████] 100%
+Progress: [██░░░░░░░░] 17% (1/6 phases)
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: install-ux
 milestone_name: Install UX
-status: executing
+status: verifying
 stopped_at: Completed 02-02-PLAN.md
-last_updated: "2026-06-04T17:13:22.318Z"
-last_activity: 2026-06-04 — Plan 02-02 complété (résolveur de deps transitives + test)
+last_updated: "2026-06-04T17:34:50.610Z"
+last_activity: 2026-06-04
 progress:
   total_phases: 5
   completed_phases: 1
-  total_plans: 2
-  completed_plans: 2
-  percent: 100
+  total_plans: 4
+  completed_plans: 3
+  percent: 75
 ---
 
 # Project State
@@ -27,10 +27,10 @@ See: .planning/PROJECT.md (updated 2026-06-04)
 
 Phase: 2 of 6 (Manifeste & résolveur) — milestone Install UX
 Plan: 2 of 2 in current phase
-Status: Executing
-Last activity: 2026-06-04 — Plan 02-02 complété (résolveur de deps transitives + test)
+Status: Phase complete — ready for verification
+Last activity: 2026-06-04
 
-Progress: [██████████] 100%
+Progress: [████████░░] 75%
 
 ## Performance Metrics
 
@@ -52,6 +52,7 @@ Progress: [██████████] 100%
 | Phase 01-dev-orchestrator P05 | ~10min | 2 tasks | 4 files |
 | Phase 02-manifeste-resolveur P01 | 5min | 2 tasks | 8 files |
 | Phase 02-manifeste-resolveur P02 | ~5min | 2 tasks | 2 files |
+| Phase 03-engine-scope-aware P01 | 3min | 3 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -68,6 +69,9 @@ Recent decisions affecting current work:
 - [Phase ?]: [Phase 1]: Modules AGENT — references sous .claude/agents/<mod>-references/ (D7), index régénéré à l'install via VF_INDEX_OUT (IDX-02) (Plan 01-05)
 - [Phase ?]: [Phase 1]: Densité des .md mesurée par wc -l, jamais le contrôleur de taille générique qui ignore les .md (Plan 01-05)
 - [Phase ?]: module.json: requires[] = prérequis module réels uniquement, ENGINE (vibeflow-update.sh) exclu
+- [Phase ?]: Engine défaut LEGACY=project (rétro-compat ./.claude) ; skill /vibeflow-install passe toujours VF_SCOPE explicite (cohérence ID4)
+- [Phase ?]: docs/<mod>/ doc-only laissé hors TARGET_ROOT (relatif au cwd projet)
+- [Phase ?]: Plus de git clone/pull : source = cache local (require_cache) ; sync = no-op explicite
 
 ### Pending Todos
 
@@ -85,6 +89,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-04T17:13:22.314Z
+Last session: 2026-06-04T17:34:33.794Z
 Stopped at: Completed 02-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: install-ux
 milestone_name: Install UX
 status: verifying
 stopped_at: Completed 02-02-PLAN.md
-last_updated: "2026-06-04T17:54:12.872Z"
+last_updated: "2026-06-04T17:57:17.926Z"
 last_activity: 2026-06-04
 progress:
   total_phases: 5
-  completed_phases: 2
+  completed_phases: 3
   total_plans: 6
-  completed_plans: 5
-  percent: 83
+  completed_plans: 6
+  percent: 100
 ---
 
 # Project State
@@ -30,7 +30,7 @@ Plan: 2 of 2 in current phase
 Status: Phase complete — ready for verification
 Last activity: 2026-06-04
 
-Progress: [████████░░] 83%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
@@ -55,6 +55,7 @@ Progress: [████████░░] 83%
 | Phase 03-engine-scope-aware P01 | 3min | 3 tasks | 2 files |
 | Phase 03 P02 | 6min | 2 tasks | 2 files |
 | Phase 04 P01 | ~1 min | 2 tasks | 3 files |
+| Phase 04 P02 | 5min | 2 tasks | 3 files |
 
 ## Accumulated Context
 
@@ -75,6 +76,7 @@ Recent decisions affecting current work:
 - [Phase ?]: docs/<mod>/ doc-only laissé hors TARGET_ROOT (relatif au cwd projet)
 - [Phase ?]: Plus de git clone/pull : source = cache local (require_cache) ; sync = no-op explicite
 - [Phase ?]: ensure-deps scope-aware via VF_SCOPE (GSD --global/--local, Superpowers --scope), VF_ENSURE_FORCE dry-run only, defaut LEGACY user (ID4)
+- [Phase ?]: Hook VibeFlow pointe directement le script bash; marqueur 1er lancement aligné sur registre engine scripts/.vibeflow-installed
 
 ### Pending Todos
 
@@ -92,6 +94,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-04T17:54:07.679Z
+Last session: 2026-06-04T17:57:03.586Z
 Stopped at: Completed 02-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: install-ux
 milestone_name: Install UX
 status: verifying
 stopped_at: Completed 02-02-PLAN.md
-last_updated: "2026-06-04T17:57:17.926Z"
+last_updated: "2026-06-04T18:18:45.956Z"
 last_activity: 2026-06-04
 progress:
   total_phases: 5
   completed_phases: 3
-  total_plans: 6
-  completed_plans: 6
-  percent: 100
+  total_plans: 8
+  completed_plans: 7
+  percent: 88
 ---
 
 # Project State
@@ -30,7 +30,7 @@ Plan: 2 of 2 in current phase
 Status: Phase complete — ready for verification
 Last activity: 2026-06-04
 
-Progress: [██████████] 100%
+Progress: [█████████░] 88%
 
 ## Performance Metrics
 
@@ -56,6 +56,7 @@ Progress: [██████████] 100%
 | Phase 03 P02 | 6min | 2 tasks | 2 files |
 | Phase 04 P01 | ~1 min | 2 tasks | 3 files |
 | Phase 04 P02 | 5min | 2 tasks | 3 files |
+| Phase 05 P01 | 2 | 3 tasks | 5 files |
 
 ## Accumulated Context
 
@@ -94,6 +95,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-04T17:57:03.586Z
+Last session: 2026-06-04T18:18:42.806Z
 Stopped at: Completed 02-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: install-ux
 milestone_name: Install UX
-status: planning
-stopped_at: Milestone Install UX scaffolté (phases 2-6), prêt pour plan-phase 2
-last_updated: "2026-06-04"
-last_activity: 2026-06-04
+status: executing
+stopped_at: Scaffolding `.planning/` terminé, prêt pour plan-phase 1
+last_updated: "2026-06-04T17:11:00.751Z"
+last_activity: 2026-06-04 — Plan 02-01 complété (8 module.json créés et validés)
 progress:
-  total_phases: 6
-  completed_phases: 1
-  total_plans: 5
-  completed_plans: 5
-  percent: 17
+  total_phases: 5
+  completed_phases: 0
+  total_plans: 2
+  completed_plans: 1
+  percent: 50
 ---
 
 # Project State
@@ -26,11 +26,11 @@ See: .planning/PROJECT.md (updated 2026-06-04)
 ## Current Position
 
 Phase: 2 of 6 (Manifeste & résolveur) — milestone Install UX
-Plan: 0 of TBD in current phase
-Status: Ready to plan
-Last activity: 2026-06-04 — Milestone Install UX scaffolté (ROADMAP/REQUIREMENTS depuis le spec)
+Plan: 1 of TBD in current phase
+Status: Executing
+Last activity: 2026-06-04 — Plan 02-01 complété (8 module.json créés et validés)
 
-Progress: [██░░░░░░░░] 17% (1/6 phases)
+Progress: [█████░░░░░] 50%
 
 ## Performance Metrics
 
@@ -50,6 +50,7 @@ Progress: [██░░░░░░░░] 17% (1/6 phases)
 | Phase 01-dev-orchestrator P03 | 12 min | 2 tasks | 2 files |
 | Phase 01 P04 | ~6 min | 2 tasks | 13 files |
 | Phase 01-dev-orchestrator P05 | ~10min | 2 tasks | 4 files |
+| Phase 02-manifeste-resolveur P01 | 5min | 2 tasks | 8 files |
 
 ## Accumulated Context
 
@@ -65,6 +66,7 @@ Recent decisions affecting current work:
 - [Phase ?]: [Phase 1]: Contrat de test VF_ENSURE_DRY_RUN=1 pour valider l'idempotence sans réseau (Plan 01-02)
 - [Phase ?]: [Phase 1]: Modules AGENT — references sous .claude/agents/<mod>-references/ (D7), index régénéré à l'install via VF_INDEX_OUT (IDX-02) (Plan 01-05)
 - [Phase ?]: [Phase 1]: Densité des .md mesurée par wc -l, jamais le contrôleur de taille générique qui ignore les .md (Plan 01-05)
+- [Phase ?]: module.json: requires[] = prérequis module réels uniquement, ENGINE (vibeflow-update.sh) exclu
 
 ### Pending Todos
 
@@ -82,6 +84,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-04T14:58:04.693Z
+Last session: 2026-06-04T17:10:34.859Z
 Stopped at: Scaffolding `.planning/` terminé, prêt pour plan-phase 1
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: install-ux
 milestone_name: Install UX
 status: executing
-stopped_at: Scaffolding `.planning/` terminé, prêt pour plan-phase 1
-last_updated: "2026-06-04T17:11:00.751Z"
-last_activity: 2026-06-04 — Plan 02-01 complété (8 module.json créés et validés)
+stopped_at: Completed 02-02-PLAN.md
+last_updated: "2026-06-04T17:13:22.318Z"
+last_activity: 2026-06-04 — Plan 02-02 complété (résolveur de deps transitives + test)
 progress:
   total_phases: 5
-  completed_phases: 0
+  completed_phases: 1
   total_plans: 2
-  completed_plans: 1
-  percent: 50
+  completed_plans: 2
+  percent: 100
 ---
 
 # Project State
@@ -26,11 +26,11 @@ See: .planning/PROJECT.md (updated 2026-06-04)
 ## Current Position
 
 Phase: 2 of 6 (Manifeste & résolveur) — milestone Install UX
-Plan: 1 of TBD in current phase
+Plan: 2 of 2 in current phase
 Status: Executing
-Last activity: 2026-06-04 — Plan 02-01 complété (8 module.json créés et validés)
+Last activity: 2026-06-04 — Plan 02-02 complété (résolveur de deps transitives + test)
 
-Progress: [█████░░░░░] 50%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
@@ -51,6 +51,7 @@ Progress: [█████░░░░░] 50%
 | Phase 01 P04 | ~6 min | 2 tasks | 13 files |
 | Phase 01-dev-orchestrator P05 | ~10min | 2 tasks | 4 files |
 | Phase 02-manifeste-resolveur P01 | 5min | 2 tasks | 8 files |
+| Phase 02-manifeste-resolveur P02 | ~5min | 2 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -84,6 +85,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-04T17:10:34.859Z
-Stopped at: Scaffolding `.planning/` terminé, prêt pour plan-phase 1
+Last session: 2026-06-04T17:13:22.314Z
+Stopped at: Completed 02-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: install-ux
 milestone_name: Install UX
 status: verifying
 stopped_at: Completed 02-02-PLAN.md
-last_updated: "2026-06-04T17:38:31.265Z"
+last_updated: "2026-06-04T17:54:12.872Z"
 last_activity: 2026-06-04
 progress:
   total_phases: 5
   completed_phases: 2
-  total_plans: 4
-  completed_plans: 4
-  percent: 100
+  total_plans: 6
+  completed_plans: 5
+  percent: 83
 ---
 
 # Project State
@@ -30,7 +30,7 @@ Plan: 2 of 2 in current phase
 Status: Phase complete — ready for verification
 Last activity: 2026-06-04
 
-Progress: [██████████] 100%
+Progress: [████████░░] 83%
 
 ## Performance Metrics
 
@@ -54,6 +54,7 @@ Progress: [██████████] 100%
 | Phase 02-manifeste-resolveur P02 | ~5min | 2 tasks | 2 files |
 | Phase 03-engine-scope-aware P01 | 3min | 3 tasks | 2 files |
 | Phase 03 P02 | 6min | 2 tasks | 2 files |
+| Phase 04 P01 | ~1 min | 2 tasks | 3 files |
 
 ## Accumulated Context
 
@@ -91,6 +92,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-04T17:38:25.512Z
+Last session: 2026-06-04T17:54:07.679Z
 Stopped at: Completed 02-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: install-ux
 milestone_name: Install UX
 status: verifying
 stopped_at: Completed 02-02-PLAN.md
-last_updated: "2026-06-04T17:34:50.610Z"
+last_updated: "2026-06-04T17:38:31.265Z"
 last_activity: 2026-06-04
 progress:
   total_phases: 5
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 4
-  completed_plans: 3
-  percent: 75
+  completed_plans: 4
+  percent: 100
 ---
 
 # Project State
@@ -30,7 +30,7 @@ Plan: 2 of 2 in current phase
 Status: Phase complete — ready for verification
 Last activity: 2026-06-04
 
-Progress: [████████░░] 75%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
@@ -53,6 +53,7 @@ Progress: [████████░░] 75%
 | Phase 02-manifeste-resolveur P01 | 5min | 2 tasks | 8 files |
 | Phase 02-manifeste-resolveur P02 | ~5min | 2 tasks | 2 files |
 | Phase 03-engine-scope-aware P01 | 3min | 3 tasks | 2 files |
+| Phase 03 P02 | 6min | 2 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -72,6 +73,7 @@ Recent decisions affecting current work:
 - [Phase ?]: Engine défaut LEGACY=project (rétro-compat ./.claude) ; skill /vibeflow-install passe toujours VF_SCOPE explicite (cohérence ID4)
 - [Phase ?]: docs/<mod>/ doc-only laissé hors TARGET_ROOT (relatif au cwd projet)
 - [Phase ?]: Plus de git clone/pull : source = cache local (require_cache) ; sync = no-op explicite
+- [Phase ?]: ensure-deps scope-aware via VF_SCOPE (GSD --global/--local, Superpowers --scope), VF_ENSURE_FORCE dry-run only, defaut LEGACY user (ID4)
 
 ### Pending Todos
 
@@ -89,6 +91,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-04T17:34:33.794Z
+Last session: 2026-06-04T17:38:25.512Z
 Stopped at: Completed 02-02-PLAN.md
 Resume file: None

--- a/.planning/phases/02-manifeste-resolveur/02-01-PLAN.md
+++ b/.planning/phases/02-manifeste-resolveur/02-01-PLAN.md
@@ -1,0 +1,211 @@
+---
+phase: 02-manifeste-resolveur
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - consolidator/module.json
+  - infrastructure-audit/module.json
+  - validator/module.json
+  - skill-creator/module.json
+  - reference/module.json
+  - software-architecture/module.json
+  - audit-architecture/module.json
+  - dev-orchestrator/module.json
+autonomous: true
+requirements: [MANIF-01]
+
+must_haves:
+  truths:
+    - "Chacun des 8 modules a un module.json à sa racine"
+    - "Chaque module.json parse en JSON valide (jq)"
+    - "Chaque module.json expose name, version, type, description, requires[]"
+    - "validator déclare requires: [consolidator, infrastructure-audit]"
+    - "Les 7 autres modules déclarent requires: [] (aucun prérequis module réel dans leur README)"
+    - "La version de chaque module.json reflète exactement le fichier VERSION du module"
+  artifacts:
+    - path: "consolidator/module.json"
+      provides: "Manifeste machine-lisible du module consolidator"
+      contains: '"name": "consolidator"'
+    - path: "infrastructure-audit/module.json"
+      provides: "Manifeste machine-lisible du module infrastructure-audit"
+      contains: '"name": "infrastructure-audit"'
+    - path: "validator/module.json"
+      provides: "Manifeste machine-lisible du module validator (avec requires)"
+      contains: '"requires"'
+    - path: "skill-creator/module.json"
+      provides: "Manifeste machine-lisible du module skill-creator"
+      contains: '"name": "skill-creator"'
+    - path: "reference/module.json"
+      provides: "Manifeste machine-lisible du module reference"
+      contains: '"name": "reference"'
+    - path: "software-architecture/module.json"
+      provides: "Manifeste machine-lisible du module software-architecture"
+      contains: '"name": "software-architecture"'
+    - path: "audit-architecture/module.json"
+      provides: "Manifeste machine-lisible du module audit-architecture"
+      contains: '"name": "audit-architecture"'
+    - path: "dev-orchestrator/module.json"
+      provides: "Manifeste machine-lisible du module dev-orchestrator"
+      contains: '"name": "dev-orchestrator"'
+  key_links:
+    - from: "validator/module.json"
+      to: "consolidator + infrastructure-audit"
+      via: "champ requires[]"
+      pattern: '"consolidator".*"infrastructure-audit"'
+    - from: "*/module.json:version"
+      to: "*/VERSION"
+      via: "valeur copiée du fichier VERSION"
+      pattern: 'v[0-9]+\.[0-9]+\.[0-9]+'
+---
+
+<objective>
+Doter chacun des 8 modules de vibeflow-os d'un fichier `module.json` à sa racine : source de
+vérité machine-lisible (name, version, type, description, requires[]) qui remplace la prose des
+READMEs pour la liste à toggles et l'auto-résolution de dépendances (MANIF-01, spec §7 / ID6).
+
+Purpose: Sans ces manifestes, ni le résolveur (Plan 02) ni le skill `/vibeflow-install` (Phase 4)
+ne peuvent agréger les modules ni résoudre leurs dépendances.
+Output: 8 fichiers `module.json` valides, un par module, versions exactes et requires réels.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+# Spec — source de vérité, section 7 « Manifeste module.json »
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+<interfaces>
+<!-- Schéma exact du module.json (spec §7). L'exécuteur applique ce schéma tel quel. -->
+
+Format module.json (un par module) :
+```json
+{
+  "name": "<slug-du-module>",
+  "version": "<contenu exact du fichier VERSION, ex. v1.1.0>",
+  "type": "<type réel parmi la table ci-dessous>",
+  "description": "<une ligne, FR, dérivée du titre/README>",
+  "requires": ["<module>", ...]
+}
+```
+
+Données factuelles à utiliser (NE PAS inventer — déjà vérifiées dans le repo) :
+
+| module                | VERSION | type                      | requires[]                              |
+|-----------------------|---------|---------------------------|-----------------------------------------|
+| consolidator          | v1.0.0  | single-skill+scripts      | []                                      |
+| infrastructure-audit  | v1.0.0  | single-skill+scripts      | []                                      |
+| validator             | v1.1.0  | agent-only                | ["consolidator","infrastructure-audit"] |
+| skill-creator         | v1.0.0  | agent+skills              | []                                      |
+| reference             | v2.1.1  | doc-only                  | []                                      |
+| software-architecture | v1.0.0  | single-skill+scripts      | []                                      |
+| audit-architecture    | v1.0.0  | single-skill+references   | []                                      |
+| dev-orchestrator      | v1.1.0  | agent+skills              | []                                      |
+
+Descriptions (1 ligne, FR) dérivées des titres README :
+- consolidator : "Consolidation de la mémoire projet sur 4 piliers."
+- infrastructure-audit : "Garde-fou technique des labs (drift Anthropic, intégrité scripts)."
+- validator : "Agent garant de l'alignement lab ↔ méthodologie (5 audits)."
+- skill-creator : "Pattern agent minimal + 2 skills composables pour créer des skills."
+- reference : "Documentation méthodologique VibeFlow (module doc-only)."
+- software-architecture : "Garde-fou d'architecture logicielle (taille fichiers, règles)."
+- audit-architecture : "Audit d'architecture logicielle d'un codebase."
+- dev-orchestrator : "Orchestrateur de développement : route le langage naturel vers le pipeline."
+
+Justification requires[] :
+- validator/README.md L26 : « Pré-requis : modules consolidator + infrastructure-audit installés ».
+- skill-creator/README.md L47 et reference/README.md L60 mentionnent un pré-requis sur
+  `vibeflow-update.sh` (l'ENGINE, pas un module) → NE COMPTE PAS comme requires[]. Donc [].
+- Les autres modules : aucune mention de prérequis module dans leur README → [].
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Créer les 8 module.json</name>
+  <files>consolidator/module.json, infrastructure-audit/module.json, validator/module.json, skill-creator/module.json, reference/module.json, software-architecture/module.json, audit-architecture/module.json, dev-orchestrator/module.json</files>
+  <action>
+Créer un fichier `module.json` à la racine de chacun des 8 modules, en suivant EXACTEMENT le
+schéma et le tableau de données du bloc <interfaces> ci-dessus (MANIF-01, spec §7 / ID6).
+
+Règles strictes :
+- `version` = contenu EXACT du fichier VERSION du module (relire chaque `<module>/VERSION` pour
+  confirmer ; ne pas hardcoder de mémoire). Format `vMAJOR.MINOR.PATCH`.
+- `type` = la valeur réelle du tableau (reflète la structure observée du module ; ne pas
+  homogénéiser).
+- `requires` = exactement le tableau (validator = ["consolidator","infrastructure-audit"], tous
+  les autres = []). NE PAS ajouter de prérequis ENGINE (vibeflow-update.sh) comme requires module.
+- Clés dans l'ordre : name, version, type, description, requires.
+- JSON pur (pas de commentaires), indentation 2 espaces, encodage UTF-8, newline finale.
+
+NE PAS modifier les README, VERSION, CHANGELOG ni aucun autre fichier. Ce plan est une fondation
+de données pure — uniquement la création des 8 module.json.
+  </action>
+  <verify>
+    <automated>for m in consolidator infrastructure-audit validator skill-creator reference software-architecture audit-architecture dev-orchestrator; do jq empty "$m/module.json" || { echo "INVALID JSON: $m"; exit 1; }; done; echo "8/8 JSON valides"</automated>
+  </verify>
+  <done>Les 8 fichiers module.json existent à la racine de leur module et parsent tous en JSON valide via jq empty.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Vérifier conformité des manifestes (champs, versions, requires)</name>
+  <files>consolidator/module.json, infrastructure-audit/module.json, validator/module.json, skill-creator/module.json, reference/module.json, software-architecture/module.json, audit-architecture/module.json, dev-orchestrator/module.json</files>
+  <action>
+Auto-vérification (lecture seule, aucune écriture sauf correction d'un module.json non conforme) :
+1. Chaque module.json expose les 5 clés requises (name, version, type, description, requires) avec
+   les bons types (name/version/type/description = string, requires = array).
+2. Pour chaque module, `version` du JSON == contenu de `<module>/VERSION`.
+3. `validator/module.json` a requires == ["consolidator","infrastructure-audit"].
+4. Les 7 autres modules ont requires == [].
+5. Chaque `name` correspond au nom du dossier.
+
+Si une non-conformité est détectée, corriger le module.json fautif (Task 1) puis relancer la
+vérification. Ne produire aucun autre artefact.
+  </action>
+  <verify>
+    <automated>fail=0; for m in consolidator infrastructure-audit validator skill-creator reference software-architecture audit-architecture dev-orchestrator; do jq -e '.name and .version and .type and .description and (.requires|type=="array")' "$m/module.json" >/dev/null || { echo "champs manquants: $m"; fail=1; }; jv=$(jq -r .version "$m/module.json"); fv=$(cat "$m/VERSION" | tr -d '[:space:]'); [ "$jv" = "$fv" ] || { echo "version mismatch $m: json=$jv VERSION=$fv"; fail=1; }; jn=$(jq -r .name "$m/module.json"); [ "$jn" = "$m" ] || { echo "name mismatch $m: $jn"; fail=1; }; done; req=$(jq -c '.requires|sort' validator/module.json); [ "$req" = '["consolidator","infrastructure-audit"]' ] || { echo "validator requires KO: $req"; fail=1; }; for m in consolidator infrastructure-audit skill-creator reference software-architecture audit-architecture dev-orchestrator; do [ "$(jq -c .requires "$m/module.json")" = "[]" ] || { echo "$m devrait avoir requires []"; fail=1; }; done; [ $fail -eq 0 ] && echo "CONFORME" || exit 1</automated>
+  </verify>
+  <done>Tous les module.json exposent les 5 champs typés correctement ; chaque version == VERSION ; validator requires == [consolidator, infrastructure-audit] ; les 7 autres requires == [].</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| fichier module.json → résolveur/skill (Plan 02, Phase 4) | données consommées par un parseur JSON et une boucle bash |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-01 | Tampering | module.json (JSON malformé casse le résolveur) | mitigate | Task 1+2 valident chaque fichier via `jq empty` et un check de schéma avant fin de plan |
+| T-02-02 | Information Disclosure | module.json (contenu) | accept | Données non sensibles (nom, version, description publique) ; aucun secret |
+| T-02-03 | Tampering | champ requires incorrect → graphe de deps faux | mitigate | Task 2 vérifie requires exactement contre les READMEs sourcés |
+</threat_model>
+
+<verification>
+- `jq empty <module>/module.json` réussit pour les 8 modules.
+- Chaque `version` JSON == `VERSION` correspondant.
+- `validator` requires == [consolidator, infrastructure-audit] ; les 7 autres == [].
+</verification>
+
+<success_criteria>
+Les 8 modules ont un module.json valide exposant name, version, type, description, requires[],
+avec versions exactes et requires réels (Success Criterion 1 de la Phase 2).
+</success_criteria>
+
+<output>
+Après complétion, créer `.planning/phases/02-manifeste-resolveur/02-01-SUMMARY.md`.
+</output>

--- a/.planning/phases/02-manifeste-resolveur/02-01-SUMMARY.md
+++ b/.planning/phases/02-manifeste-resolveur/02-01-SUMMARY.md
@@ -1,0 +1,82 @@
+---
+phase: 02-manifeste-resolveur
+plan: 01
+subsystem: manifeste-modules
+tags: [module.json, manifeste, foundation-data]
+requires: []
+provides:
+  - "8 module.json (un par module) — source de vérité machine-lisible"
+  - "graphe de dépendances modules (champ requires[])"
+affects:
+  - "Plan 02-02 (résolveur de dépendances)"
+  - "Phase 4 (/vibeflow-install)"
+tech-stack:
+  added: []
+  patterns: ["manifeste JSON par module (name/version/type/description/requires)"]
+key-files:
+  created:
+    - consolidator/module.json
+    - infrastructure-audit/module.json
+    - validator/module.json
+    - skill-creator/module.json
+    - reference/module.json
+    - software-architecture/module.json
+    - audit-architecture/module.json
+    - dev-orchestrator/module.json
+  modified: []
+decisions:
+  - "requires[] = prérequis MODULE réels uniquement ; vibeflow-update.sh (ENGINE) exclu → skill-creator/reference = []"
+  - "type non homogénéisé : reflète la structure observée de chaque module"
+metrics:
+  duration: ~5min
+  completed: 2026-06-04
+  tasks: 2
+  files: 8
+requirements: [MANIF-01]
+---
+
+# Phase 2 Plan 01 : Manifeste module.json Summary
+
+Dotation des 8 modules vibeflow-os d'un `module.json` racine (name, version, type, description, requires[]), versions copiées des fichiers VERSION réels et graphe de dépendances réel encodé (MANIF-01).
+
+## What Was Built
+
+8 fichiers `module.json`, un par module, schéma identique (spec §7), clés dans l'ordre name → version → type → description → requires, indentation 2 espaces, newline finale.
+
+| module | version (VERSION confirmé) | type | requires[] |
+|--------|----------------------------|------|------------|
+| consolidator | v1.0.0 | single-skill+scripts | [] |
+| infrastructure-audit | v1.0.0 | single-skill+scripts | [] |
+| validator | v1.1.0 | agent-only | ["consolidator","infrastructure-audit"] |
+| skill-creator | v1.0.0 | agent+skills | [] |
+| reference | v2.1.1 | doc-only | [] |
+| software-architecture | v1.0.0 | single-skill+scripts | [] |
+| audit-architecture | v1.0.0 | single-skill+references | [] |
+| dev-orchestrator | v1.1.0 | agent+skills | [] |
+
+## Tasks
+
+| Task | Nom | Verify | Commit |
+|------|-----|--------|--------|
+| 1 | Créer les 8 module.json | `jq empty` 8/8 → exit 0 | c89a5dc |
+| 2 | Vérifier conformité (champs, versions, requires) | check schéma+version+name+requires → CONFORME, exit 0 | (read-only, aucune correction nécessaire) |
+
+## Verification
+
+- Task 1 : `jq empty` sur les 8 fichiers → « 8/8 JSON valides », exit 0.
+- Task 2 : 5 champs typés présents ; version JSON == VERSION pour chaque module ; name == nom du dossier ; validator requires == [consolidator, infrastructure-audit] ; 7 autres == [] → « CONFORME », exit 0.
+- Les VERSION ont été relus directement avant écriture : toutes alignées sur la table du plan.
+
+## Deviations from Plan
+
+None - plan exécuté exactement comme écrit. Aucune non-conformité détectée en Task 2, donc aucune correction ni commit supplémentaire.
+
+## Threat Mitigations Applied
+
+- T-02-01 (Tampering / JSON malformé) : mitigé — `jq empty` valide chaque fichier (Task 1) + check de schéma (Task 2).
+- T-02-03 (Tampering / requires incorrect) : mitigé — requires vérifiés contre les READMEs sourcés (validator L26 ; skill-creator/reference excluent l'ENGINE).
+
+## Self-Check: PASSED
+
+- 8 module.json : tous FOUND.
+- Commit c89a5dc : FOUND.

--- a/.planning/phases/02-manifeste-resolveur/02-02-PLAN.md
+++ b/.planning/phases/02-manifeste-resolveur/02-02-PLAN.md
@@ -1,0 +1,201 @@
+---
+phase: 02-manifeste-resolveur
+plan: 02
+type: execute
+wave: 2
+depends_on: [01]
+files_modified:
+  - _internal/resolve-deps.sh
+  - _internal/tests/test-resolve-deps.sh
+autonomous: true
+requirements: [MANIF-02]
+
+must_haves:
+  truths:
+    - "resolve-deps.sh, donné une liste de modules, retourne la fermeture transitive triée et dédupliquée"
+    - "resolve-deps.sh [validator] retourne consolidator, infrastructure-audit, validator (closure transitive)"
+    - "resolve-deps.sh d'un module sans requires retourne ce module seul"
+    - "resolve-deps.sh ne duplique jamais un module présent via plusieurs chemins"
+    - "resolve-deps.sh échoue proprement (exit non-zéro) sur un module inconnu"
+    - "Le test test-resolve-deps.sh passe (exit 0) avec des asserts numérotés"
+  artifacts:
+    - path: "_internal/resolve-deps.sh"
+      provides: "Résolveur de fermeture transitive des requires des module.json"
+      min_lines: 30
+      contains: "set -euo pipefail"
+    - path: "_internal/tests/test-resolve-deps.sh"
+      provides: "Test autonome du résolveur (asserts numérotés, exit 0/1)"
+      min_lines: 20
+      contains: "validator"
+  key_links:
+    - from: "_internal/resolve-deps.sh"
+      to: "<module>/module.json"
+      via: "lecture du champ requires via jq"
+      pattern: 'jq.*requires'
+    - from: "_internal/tests/test-resolve-deps.sh"
+      to: "_internal/resolve-deps.sh"
+      via: "invocation bash du script sous test"
+      pattern: 'resolve-deps\.sh'
+---
+
+<objective>
+Créer un résolveur de dépendances (`_internal/resolve-deps.sh`) qui, donné une liste de modules,
+lit leurs `module.json`, suit récursivement les `requires`, et retourne la fermeture transitive
+triée et dédupliquée. Plus un test autonome qui prouve le comportement (MANIF-02, spec §7 / ID6).
+
+Purpose: C'est le cœur de l'auto-résolution de dépendances que le skill `/vibeflow-install`
+(Phase 4) et l'engine scope-aware (Phase 3) consommeront pour récapituler et installer les bons
+modules. Fondation testable isolément.
+Output: `_internal/resolve-deps.sh` + `_internal/tests/test-resolve-deps.sh`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+# Spec — source de vérité, section 7 (résolveur agrège les module.json)
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+# Les manifestes que le résolveur lit (produits par le Plan 01)
+@validator/module.json
+@consolidator/module.json
+@infrastructure-audit/module.json
+
+<interfaces>
+<!-- Pattern de script bash du repo (à reproduire). Extrait de _internal/vibeflow-update.sh -->
+Shebang + options + helpers :
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+log() { echo "[resolve-deps] $*" >&2; }
+err() { echo "[resolve-deps] ERROR: $*" >&2; exit 1; }
+```
+
+<!-- Pattern de test du repo (à reproduire). Extrait de software-architecture/scripts/tests/test-check-file-size.sh -->
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+pass=0; fail=0
+ok()   { echo "  ✓ $1"; pass=$((pass+1)); }
+ko()   { echo "  ✗ $1"; fail=$((fail+1)); }
+# ... asserts numérotés ...
+echo "== résultat : $pass OK / $fail KO =="
+[ "$fail" -eq 0 ]
+```
+
+<!-- Localisation des module.json : <repo-root>/<module>/module.json (8 modules, Plan 01). -->
+<!-- requires[] dans validator/module.json == ["consolidator","infrastructure-audit"]. -->
+<!-- jq est disponible sur la machine de dev (jq-1.7.1). -->
+
+Contrat du résolveur :
+- Usage : `resolve-deps.sh <module> [<module> ...]`  (ou lit stdin, au choix de l'exécuteur —
+  documenter le choix en tête de script).
+- Racine des modules : par défaut le parent du dossier du script (`_internal/..`), surchargeable
+  via une variable d'env (ex. `VF_MODULES_ROOT`) pour permettre au test d'injecter des fixtures.
+- Sortie : un module par ligne sur stdout, triée alpha, dédupliquée, incluant les entrées
+  d'origine ET toutes leurs deps transitives.
+- Erreurs : module inconnu (module.json absent) → message sur stderr + exit non-zéro.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Écrire le test du résolveur (RED) puis le résolveur (GREEN)</name>
+  <files>_internal/tests/test-resolve-deps.sh, _internal/resolve-deps.sh</files>
+  <behavior>
+    - Test 1 : resolve-deps.sh validator → sortie == {consolidator, infrastructure-audit, validator} (triée, 3 lignes)
+    - Test 2 : resolve-deps.sh consolidator → sortie == {consolidator} (1 ligne, module sans requires)
+    - Test 3 : resolve-deps.sh validator consolidator → pas de doublon (consolidator apparaît une seule fois)
+    - Test 4 : resolve-deps.sh <module-inconnu> → exit non-zéro (≠ 0)
+    - Test 5 : sortie triée alphabétiquement (consolidator avant infrastructure-audit avant validator)
+  </behavior>
+  <action>
+TDD strict (RED → GREEN), surcharge VF_MODULES_ROOT pour pointer le test sur les vrais module.json
+du repo (produits par Plan 01) ou sur des fixtures temporaires.
+
+RED :
+1. Créer `_internal/tests/test-resolve-deps.sh` sur le pattern de
+   `software-architecture/scripts/tests/test-check-file-size.sh` (set -uo pipefail, helpers
+   ok/ko, asserts numérotés, `echo "== résultat ..."`, `[ "$fail" -eq 0 ]` en sortie).
+   Couvrir les 5 comportements du bloc <behavior>. Pour le test, faire pointer le résolveur sur la
+   racine du repo via la variable d'env documentée (ex. `VF_MODULES_ROOT="$REPO_ROOT"`), où
+   REPO_ROOT = `$(cd "$(dirname "$0")/../.." && pwd)`.
+2. Lancer le test : il DOIT échouer (résolveur absent). Commit `test(02-02): add failing test for resolve-deps`.
+
+GREEN :
+3. Créer `_internal/resolve-deps.sh` (shebang, `set -euo pipefail`, helpers log/err du bloc
+   <interfaces>). Algorithme : parcours en largeur/profondeur d'une file de modules à traiter ;
+   pour chaque module, lire `requires` via `jq -r '.requires[]?' "$ROOT/$mod/module.json"` ;
+   ajouter les nouveaux modules non encore vus à la file ; marquer vu pour dédupliquer ; si le
+   module.json est absent → err + exit non-zéro. En fin : émettre l'ensemble vu, trié (`sort`),
+   un par ligne. Racine = `${VF_MODULES_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}`.
+4. Lancer le test : il DOIT passer. Commit `feat(02-02): implement transitive dependency resolver`.
+
+NE PAS toucher à vibeflow-update.sh ni intégrer le résolveur dans l'engine (Phase 3). Ce plan
+livre le script + son test, isolés.
+  </action>
+  <verify>
+    <automated>bash _internal/tests/test-resolve-deps.sh</automated>
+  </verify>
+  <done>Le test test-resolve-deps.sh sort en exit 0 ; resolve-deps.sh validator retourne consolidator, infrastructure-audit, validator triés ; un module inconnu provoque un exit non-zéro.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Vérifier la closure transitive de bout en bout</name>
+  <files>_internal/resolve-deps.sh</files>
+  <action>
+Vérification d'intégration (lecture seule, aucune écriture sauf correction du résolveur si un
+écart est trouvé) : exécuter le résolveur contre les VRAIS module.json du repo (pas seulement les
+fixtures de test) et confirmer :
+1. `resolve-deps.sh validator` retourne exactement les 3 lignes : consolidator, infrastructure-audit, validator.
+2. La sortie est triée et sans doublon.
+3. Un module isolé sans requires (ex. reference) retourne une seule ligne.
+Si écart → corriger resolve-deps.sh (Task 1) et relancer le test du Task 1.
+  </action>
+  <verify>
+    <automated>out=$(VF_MODULES_ROOT="$(pwd)" bash _internal/resolve-deps.sh validator); exp=$(printf 'consolidator\ninfrastructure-audit\nvalidator'); [ "$out" = "$exp" ] || { echo "closure KO:"; echo "$out"; exit 1; }; r=$(VF_MODULES_ROOT="$(pwd)" bash _internal/resolve-deps.sh reference); [ "$r" = "reference" ] || { echo "module isolé KO: $r"; exit 1; }; echo "CLOSURE OK"</automated>
+  </verify>
+  <done>resolve-deps.sh validator == {consolidator, infrastructure-audit, validator} trié ; un module sans requires retourne lui-même seul.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| liste de modules (argv/stdin) → résolveur | entrée potentiellement non valide (module inexistant) |
+| module.json → jq dans le résolveur | données externes parsées en boucle |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-04 | Tampering | input module inconnu → boucle infinie / faux résultat | mitigate | set de modules « vus » pour borner la récursion + err/exit non-zéro sur module.json absent (Test 4) |
+| T-02-05 | Denial of Service | cycle de requires (A→B→A) → boucle infinie | mitigate | marquage « vu » avant d'enfiler les deps garantit la terminaison même en cas de cycle |
+| T-02-06 | Tampering | module.json malformé fait planter jq | accept | les manifestes sont validés en Plan 01 (jq empty) ; entrée de confiance interne au repo |
+</threat_model>
+
+<verification>
+- `bash _internal/tests/test-resolve-deps.sh` sort en exit 0.
+- `resolve-deps.sh validator` == {consolidator, infrastructure-audit, validator} trié.
+- Module inconnu → exit non-zéro ; module sans requires → lui-même seul ; pas de doublon.
+</verification>
+
+<success_criteria>
+Le résolveur retourne la fermeture transitive correcte d'une sélection (validator → +consolidator
++infrastructure-audit), triée et dédupliquée, prouvé par un test automatisé (Success Criterion 2
+de la Phase 2).
+</success_criteria>
+
+<output>
+Après complétion, créer `.planning/phases/02-manifeste-resolveur/02-02-SUMMARY.md`.
+</output>

--- a/.planning/phases/02-manifeste-resolveur/02-02-SUMMARY.md
+++ b/.planning/phases/02-manifeste-resolveur/02-02-SUMMARY.md
@@ -1,0 +1,81 @@
+---
+phase: 02-manifeste-resolveur
+plan: 02
+subsystem: dependency-resolver
+tags: [bash, jq, tdd, dependency-resolution, module-manifest]
+requires:
+  - "Plan 01 : module.json présents à <repo-root>/<module>/module.json (8 modules)"
+provides:
+  - "_internal/resolve-deps.sh : fermeture transitive triée + dédupliquée des requires"
+  - "_internal/tests/test-resolve-deps.sh : test autonome (5 asserts)"
+affects:
+  - "Phase 3 (engine scope-aware) et Phase 4 (/vibeflow-install) consommeront le résolveur"
+tech-stack:
+  added: []
+  patterns:
+    - "BFS sur file de modules + set « vu » (anti-cycle, dédup)"
+    - "jq -r '.requires[]?' pour lire les deps"
+    - "VF_MODULES_ROOT surchargeable pour fixtures de test"
+    - "Pattern test repo : helpers ok/ko, asserts numérotés, exit 0/1"
+key-files:
+  created:
+    - _internal/resolve-deps.sh
+    - _internal/tests/test-resolve-deps.sh
+  modified: []
+decisions:
+  - "Contrat d'entrée : argv (resolve-deps.sh <module> [<module> ...]), pas stdin"
+  - "Racine modules : ${VF_MODULES_ROOT:-parent du dossier du script}"
+  - "Marquage « vu » AVANT enfilage des deps → terminaison garantie même en cycle"
+metrics:
+  duration: ~5min
+  completed: 2026-06-04
+  tasks: 2
+  files: 2
+  commits: 3
+---
+
+# Phase 02 Plan 02 : Résolveur de dépendances transitives Summary
+
+Résolveur bash `_internal/resolve-deps.sh` qui calcule la fermeture transitive des `requires` des `module.json` (BFS + dédup + tri via `sort -u`), avec sécurité anti-cycle et exit non-zéro sur module inconnu, prouvé par un test autonome à 5 asserts (TDD RED→GREEN).
+
+## What Was Built
+
+- **`_internal/resolve-deps.sh`** (47 lignes) — Lit `${VF_MODULES_ROOT:-parent}/<mod>/module.json`, suit récursivement `requires` via `jq -r '.requires[]?'`, parcours en largeur (file `queue`) avec set `seen` marqué avant enfilage des deps (anti-cycle + dédup), émet la fermeture triée (`sort -u`) un module par ligne. `err`/exit non-zéro si un manifeste est absent.
+- **`_internal/tests/test-resolve-deps.sh`** (44 lignes) — Test autonome pointant sur les vrais `module.json` du repo via `VF_MODULES_ROOT=$REPO_ROOT`. 5 asserts numérotés : (1) `validator` → closure triée 3 lignes, (2) `consolidator` → lui-même seul, (3) `validator consolidator` → pas de doublon, (4) module inconnu → exit non-zéro, (5) sortie triée alphabétiquement.
+
+## Verification Results
+
+| Étape | Commande | Résultat |
+|-------|----------|----------|
+| RED | `bash _internal/tests/test-resolve-deps.sh` (résolveur absent) | exit 1 — 3 asserts cœur KO (attendu) |
+| GREEN | `bash _internal/tests/test-resolve-deps.sh` | exit 0 — 5 OK / 0 KO |
+| Task 1 verify | `bash _internal/tests/test-resolve-deps.sh` | exit 0 |
+| Task 2 verify | closure `validator` == {consolidator, infrastructure-audit, validator} + `reference` == reference | exit 0 — `CLOSURE OK` |
+| Robustesse (hors plan) | cycle A↔B sur fixture temp | termine, sortie `a b`, exit 0 (T-02-05 confirmé) |
+
+## TDD Gate Compliance
+
+- RED gate : commit `test(02-02): add failing test for resolve-deps` (f25233f) — test échoue avant implémentation.
+- GREEN gate : commit `feat(02-02): implement transitive dependency resolver` (f0ffe75) — test passe après implémentation.
+- REFACTOR gate : non nécessaire (implémentation propre dès le GREEN).
+
+## Threat Mitigations Applied
+
+- **T-02-04 (input module inconnu)** : `[ -f "$manifest" ] || err ...` → message stderr + exit non-zéro (Test 4).
+- **T-02-05 (cycle de requires)** : `seen` marqué avant d'enfiler les deps → terminaison garantie ; vérifié manuellement sur fixture A↔B.
+- **T-02-06 (module.json malformé)** : accepté (manifestes validés en Plan 01, entrée de confiance interne).
+
+## Deviations from Plan
+
+None - plan exécuté exactement comme écrit. Aucune correction du résolveur nécessaire en Task 2 (closure correcte du premier coup).
+
+## Known Stubs
+
+None.
+
+## Self-Check: PASSED
+
+- FOUND: _internal/resolve-deps.sh
+- FOUND: _internal/tests/test-resolve-deps.sh
+- FOUND commit: f25233f (test RED)
+- FOUND commit: f0ffe75 (feat GREEN)

--- a/.planning/phases/03-engine-scope-aware/03-01-PLAN.md
+++ b/.planning/phases/03-engine-scope-aware/03-01-PLAN.md
@@ -1,0 +1,248 @@
+---
+phase: 03-engine-scope-aware
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - _internal/vibeflow-update.sh
+  - _internal/tests/test-vibeflow-update.sh
+autonomous: true
+requirements: [SCOPE-01, SCOPE-02, SCOPE-04]
+must_haves:
+  truths:
+    - "Un appel `VF_SCOPE=user install <mod>` (HOME de test) écrit les artefacts sous $HOME/.claude, pas sous ./.claude"
+    - "Un appel sans scope (ou `--scope project`) installe sous ./.claude (comportement actuel inchangé)"
+    - "Un appel `--scope local install <mod>` ajoute les chemins installés au .gitignore (idempotent, sans doublon)"
+    - "Le script ne clone plus jamais le repo (aucun `git clone` exécutable dans le code)"
+    - "L'engine peut résoudre la fermeture transitive d'un module avant de l'installer (résolveur intégré)"
+  artifacts:
+    - path: "_internal/vibeflow-update.sh"
+      provides: "Engine scope-aware : TARGET_ROOT résolu, source = cache, gitignore local, résolveur câblé"
+      contains: "TARGET_ROOT"
+    - path: "_internal/tests/test-vibeflow-update.sh"
+      provides: "Tests isolés (HOME/TARGET_ROOT temporaire) des 5 truths"
+      contains: "mktemp"
+  key_links:
+    - from: "_internal/vibeflow-update.sh"
+      to: "TARGET_ROOT"
+      via: "résolution VF_SCOPE → $HOME/.claude | ./.claude"
+      pattern: "TARGET_ROOT"
+    - from: "_internal/vibeflow-update.sh"
+      to: "_internal/resolve-deps.sh"
+      via: "appel du résolveur pour la fermeture transitive"
+      pattern: "resolve-deps"
+---
+
+<objective>
+Rendre `_internal/vibeflow-update.sh` scope-aware : toutes les cibles d'install/uninstall/backup/status,
+aujourd'hui codées en dur sur `./.claude`, deviennent relatives à un `TARGET_ROOT` résolu depuis
+`VF_SCOPE` / `--scope`. Supprimer le clone git automatique (la source = cache fourni par l'appelant).
+Ajouter le scope `local` → `.gitignore`. Câbler le résolveur de Phase 2.
+
+Purpose: SCOPE-01 (TARGET_ROOT), SCOPE-02 (plus de git clone), SCOPE-04 (gitignore local), et
+l'intégration du résolveur — fondation engine du milestone Install UX. Sans ça, le skill /vibeflow-install
+(Phase 4) n'a rien à orchestrer.
+
+Output: `vibeflow-update.sh` scope-aware + suppression du clone + résolveur câblé, et un test isolé
+(`_internal/tests/test-vibeflow-update.sh`) qui valide les 5 truths sans toucher au vrai `~/.claude`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+# Engine actuel à étendre (lire en entier — NE PAS casser l'existant)
+@_internal/vibeflow-update.sh
+
+# Résolveur de Phase 2 à intégrer
+@_internal/resolve-deps.sh
+
+# Pattern de test isolé (HOME/cache temporaire) — voir surtout T6 (install e2e en lab mktemp)
+@dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
+@_internal/tests/test-resolve-deps.sh
+
+<interfaces>
+<!-- Contrats utilisés/produits par ce plan. L'exécuteur s'appuie dessus sans explorer le repo. -->
+
+Résolveur (à appeler depuis l'engine) — _internal/resolve-deps.sh :
+  Usage : resolve-deps.sh <module> [<module> ...]
+  - Lit ${VF_MODULES_ROOT:-<parent du dossier du script>}/<mod>/module.json
+  - Émet sur stdout la fermeture transitive (entrées + deps), triée, dédupliquée, 1 module/ligne
+  - module.json absent → message stderr + exit non-zéro
+  Pour intégration : VF_MODULES_ROOT doit pointer sur le CACHE (CACHE_DIR), pas sur le repo.
+
+Variables actuelles de l'engine (à conserver/étendre) :
+  CACHE_DIR="${VIBEFLOW_CACHE:-.vibeflow-cache}"   # devient la SEULE source (plus de clone)
+  INSTALLED_REGISTRY=".claude/scripts/.vibeflow-installed"  # → $TARGET_ROOT/scripts/.vibeflow-installed
+  BACKUP_DIR=".claude/.backups"                    # → $TARGET_ROOT/.backups
+
+Cibles d'install codées en dur à rebaser sur $TARGET_ROOT (toutes les occurrences `.claude/`) :
+  .claude/skills/<mod>/, .claude/agents/<mod>.md, .claude/agents/<mod>-references/,
+  .claude/rules/, .claude/scripts/, docs/<mod>/ (doc-only — reste relatif au cwd projet),
+  .claude/scripts/build-gsd-index.sh (hook IDX-02).
+
+Mapping scope (spec §3) :
+  user           → TARGET_ROOT="$HOME/.claude"
+  project | local → TARGET_ROOT="./.claude"   (local ajoute en plus au .gitignore)
+  défaut (aucun) → project (rétro-compat)
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Résolution VF_SCOPE → TARGET_ROOT + suppression du clone git</name>
+  <files>_internal/vibeflow-update.sh</files>
+  <action>
+Rendre l'engine scope-aware et supprimer toute logique de clone (SCOPE-01 + SCOPE-02).
+
+1. Parsing du scope (en tête, après les `set`/variables) :
+   - Lire `VF_SCOPE` (env) avec défaut `project` (rétro-compat — D du milestone).
+   - Accepter aussi un flag `--scope <user|project|local>` côté Main : le détecter AVANT
+     `cmd="$1"` (boucle ou shift simple), retirer `--scope X` des positionnels, et override `VF_SCOPE`.
+   - Valider la valeur : `user|project|local` sinon `err "scope invalide : $VF_SCOPE (attendu user|project|local)"`.
+   - Résoudre `TARGET_ROOT` : `user`→`"$HOME/.claude"` ; `project|local`→`"./.claude"`.
+     Conserver le scope dans une variable `VF_SCOPE` exportée pour les autres fonctions.
+
+2. Rebaser TOUTES les cibles `.claude/...` sur `$TARGET_ROOT` :
+   - `INSTALLED_REGISTRY="$TARGET_ROOT/scripts/.vibeflow-installed"`
+   - `BACKUP_DIR="$TARGET_ROOT/.backups"`
+   - Dans `install_module`, `backup_module`, `rollback_module`, `uninstall_module` : remplacer chaque
+     `.claude/skills/`, `.claude/agents/`, `.claude/rules/`, `.claude/scripts/` par `$TARGET_ROOT/skills/` etc.
+   - EXCEPTION : `docs/<mod>/` (Type 4 doc-only) reste relatif au cwd projet (ce n'est pas du `.claude`).
+     Documenter ce choix en commentaire.
+   - Le hook IDX-02 (`build-gsd-index.sh`, `VF_INDEX_OUT`) doit pointer sur `$TARGET_ROOT/agents/...`.
+
+3. Supprimer le clone (SCOPE-02) :
+   - Supprimer la fonction `ensure_cache` (le clone) et `sync_cache` (git pull). Supprimer la
+     constante `REPO_URL`. Remplacer tous les appels `ensure_cache`/`sync_cache` par une nouvelle
+     fonction `require_cache` qui vérifie seulement que `$CACHE_DIR` existe, sinon
+     `err "Cache introuvable : $CACHE_DIR (fournir VIBEFLOW_CACHE)"`. AUCUN `git` ne doit subsister.
+   - La commande `sync` du Main : la retirer OU la transformer en no-op explicite qui logue
+     « source = cache fourni (VIBEFLOW_CACHE), plus de sync git ». Mettre à jour le bloc d'usage en tête
+     (commentaires `# ...`) pour refléter la nouvelle source et `--scope`.
+   - `update_module` appelait `sync_cache` : remplacer par `require_cache`.
+
+4. Conserver le comportement par défaut : sans `--scope` ni `VF_SCOPE`, `TARGET_ROOT=./.claude`
+   (identique à aujourd'hui). Ne changer AUCUN nom de module, AUCUN type de module (les 5 types + D7).
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'bash -n _internal/vibeflow-update.sh && ! command grep -nE "git clone|git pull|REPO_URL" _internal/vibeflow-update.sh && command grep -q "TARGET_ROOT" _internal/vibeflow-update.sh && echo OK'</automated>
+  </verify>
+  <done>`bash -n` OK ; aucun `git clone`/`git pull`/`REPO_URL` dans le script ; `TARGET_ROOT` présent et utilisé pour les cibles.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Gitignore local (SCOPE-04) + intégration du résolveur</name>
+  <files>_internal/vibeflow-update.sh</files>
+  <action>
+Ajouter le comportement `local` et câbler le résolveur de Phase 2.
+
+1. SCOPE-04 — gitignore local :
+   - Nouvelle fonction `gitignore_add_paths(mod)` : si `VF_SCOPE=local`, ajouter au `./.gitignore`
+     (cwd projet) les chemins installés du module, idempotent (pas de doublon).
+   - Chemins à ignorer (relatifs au projet, donc `.claude/...`) selon ce que le module a posé :
+     `.claude/skills/<mod>/`, `.claude/agents/<mod>.md`, `.claude/agents/<mod>-references/`,
+     et pour les rules/scripts, les fichiers réellement copiés (réutiliser la liste depuis le
+     `module_dir`). Implémentation idempotente : pour chaque chemin, `command grep -qxF "$path" .gitignore`
+     avant d'`echo "$path" >> .gitignore` ; créer `.gitignore` s'il manque.
+   - Appeler `gitignore_add_paths "$mod"` à la fin de `install_module` UNIQUEMENT si `VF_SCOPE=local`.
+   - Pour scope `user`/`project` : ne JAMAIS toucher au `.gitignore`.
+
+2. Intégration du résolveur (closure d'install) :
+   - Localiser `resolve-deps.sh` : il est livré dans le cache (`$CACHE_DIR/_internal/resolve-deps.sh`)
+     ou à côté de l'engine (`$(dirname "$0")/resolve-deps.sh`). Prendre le premier existant.
+   - Nouvelle fonction `resolve_closure(mod...)` : appelle `VF_MODULES_ROOT="$CACHE_DIR" bash <resolver> "$@"`
+     et renvoie la liste (1/ligne). Si le résolveur est absent, fallback = renvoyer les args tels quels
+     (best-effort, log un warning) — ne JAMAIS faire échouer l'install pour ça.
+   - Exposer une option `--with-deps` sur `install` : `install --with-deps <mod>` installe la fermeture
+     transitive (chaque module de `resolve_closure <mod>` via `install_module`), en respectant le scope.
+     Sans `--with-deps`, comportement actuel (un seul module). Mettre à jour le bloc d'usage en tête.
+   - `VF_MODULES_ROOT` pointe sur le CACHE (pas le repo) car les `module.json` sont dans le cache.
+
+3. Ne pas régresser : `install <mod>` seul reste équivalent à aujourd'hui (hors TARGET_ROOT).
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'bash -n _internal/vibeflow-update.sh && command grep -q "gitignore" _internal/vibeflow-update.sh && command grep -q "resolve-deps" _internal/vibeflow-update.sh && command grep -q -- "--with-deps" _internal/vibeflow-update.sh && echo OK'</automated>
+  </verify>
+  <done>`bash -n` OK ; fonction gitignore présente ; résolveur référencé (`resolve-deps`) ; option `--with-deps` câblée. Le `.gitignore` n'est touché qu'en scope `local`.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Test isolé de l'engine scope-aware (HOME/cache temporaires)</name>
+  <files>_internal/tests/test-vibeflow-update.sh</files>
+  <behavior>
+    - T1 (user) : `HOME=$(mktemp -d) VF_SCOPE=user VIBEFLOW_CACHE=$cache install dev-orchestrator` → l'agent est écrit sous `$HOME/.claude/agents/dev-orchestrator.md` ET RIEN n'apparaît sous `./.claude` dans le lab.
+    - T2 (project défaut) : sans VF_SCOPE, dans un lab mktemp, install → artefacts sous `./.claude/` (comportement actuel) ; rétro-compat dev-orchestrator (agent + references D7 présents).
+    - T3 (local → gitignore) : `VF_SCOPE=local install dev-orchestrator` dans un lab → `.gitignore` du lab contient le chemin `.claude/agents/dev-orchestrator.md` ; un 2e run n'ajoute PAS de doublon (idempotent : `grep -c` du chemin == 1).
+    - T4 (no clone) : aucune chaîne `git clone`/`git pull` dans le script (asserts statique sur le source).
+    - T5 (résolveur) : `resolve_closure`/`--with-deps validator` installe la fermeture (validator + consolidator + infrastructure-audit) — SKIP propre si les module.json manquent dans le cache.
+  </behavior>
+  <action>
+Créer `_internal/tests/test-vibeflow-update.sh` sur le pattern du repo (helpers `ok/ko/skip`,
+`GREP="$(command -v grep)"`, asserts numérotés, `exit 0` si tout passe, `exit 1` si un KO).
+
+ISOLATION OBLIGATOIRE — ne JAMAIS toucher au vrai `~/.claude` :
+- Pour chaque test : `LAB="$(mktemp -d)"`, `CACHE="$LAB/cache"`, copier le module
+  dev-orchestrator (et pour T5, validator + ses deps) dans `$CACHE/<mod>/` avec leurs `module.json`.
+- Test `user` : `HOME="$LAB/home"` (mktemp dédié) — asserter l'écriture sous `$HOME/.claude`
+  ET l'absence sous `$LAB/.claude`. Exécuter depuis `(cd "$LAB" && ...)`.
+- Test `project`/`local` : exécuter depuis `(cd "$LAB" && VIBEFLOW_CACHE="$CACHE" ...)`, asserts
+  sur `$LAB/.claude/...` et `$LAB/.gitignore`.
+- `trap 'rm -rf "$LAB"...' EXIT` ou nettoyage explicite par test.
+- Les `bash -c`/grep tournent via `"$GREP"` (binaire système, alias ugrep neutralisé).
+
+Implémenter T1..T5 ci-dessus. T4 = assert statique (`! "$GREP" -nE 'git clone|git pull' "$INSTALLER"`).
+Mettre des SKIP non bloquants si un module/module.json requis n'est pas copiable, jamais de faux négatif.
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'bash -n _internal/tests/test-vibeflow-update.sh && HOME_BEFORE=$(ls -A "$HOME/.claude" 2>/dev/null | wc -l); bash _internal/tests/test-vibeflow-update.sh; rc=$?; HOME_AFTER=$(ls -A "$HOME/.claude" 2>/dev/null | wc -l); [ "$HOME_BEFORE" = "$HOME_AFTER" ] && [ "$rc" -eq 0 ] && echo "OK (rc=$rc, ~/.claude intact)"'</automated>
+  </verify>
+  <done>Le test passe (exit 0) ET le vrai `~/.claude` est inchangé (même nb d'entrées avant/après). T1..T5 couvrent user/project/local/no-clone/résolveur.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| appelant → engine (arg `<module>`, env `VF_SCOPE`/`VIBEFLOW_CACHE`) | entrée potentiellement non validée injectée dans des chemins de fichiers |
+| cache plugin → système de fichiers (`cp` depuis `$CACHE_DIR`) | contenu du cache copié vers `$TARGET_ROOT` |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-03-01 | Tampering | `TARGET_ROOT` via `VF_SCOPE` | mitigate | Valider `VF_SCOPE ∈ {user,project,local}` avant résolution ; `err` sinon (Task 1). |
+| T-03-02 | Elevation | écriture `gitignore`/cibles via `$mod` | accept | `$mod` provient de l'appelant local (CLI dev), pas d'une source réseau ; même surface que l'engine actuel. |
+| T-03-03 | Information disclosure | suppression du clone réseau | mitigate | SCOPE-02 supprime tout accès réseau (`git clone`) → réduit la surface ; source = cache local fourni. |
+</threat_model>
+
+<verification>
+- `bash -n` sur l'engine et le test (syntaxe).
+- Aucun `git clone`/`git pull`/`REPO_URL` dans l'engine (`command grep` statique).
+- `test-vibeflow-update.sh` passe (exit 0) et laisse `~/.claude` intact.
+- Rétro-compat : install sans scope dans un lab pose les artefacts sous `./.claude` (T2).
+</verification>
+
+<success_criteria>
+- SCOPE-01 : `VF_SCOPE=user` cible `$HOME/.claude`, `project`/`local` cible `./.claude` (test T1/T2).
+- SCOPE-02 : plus aucun `git clone` dans l'engine ; source = `VIBEFLOW_CACHE` (test T4).
+- SCOPE-04 : `local` ajoute au `.gitignore` sans doublon (test T3).
+- Résolveur câblé : `--with-deps validator` installe la fermeture transitive (test T5).
+- Le vrai `~/.claude` n'est jamais pollué par les tests.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-engine-scope-aware/03-01-SUMMARY.md`
+</output>

--- a/.planning/phases/03-engine-scope-aware/03-01-PLAN.md
+++ b/.planning/phases/03-engine-scope-aware/03-01-PLAN.md
@@ -12,16 +12,16 @@ requirements: [SCOPE-01, SCOPE-02, SCOPE-04]
 must_haves:
   truths:
     - "Un appel `VF_SCOPE=user install <mod>` (HOME de test) écrit les artefacts sous $HOME/.claude, pas sous ./.claude"
-    - "Un appel sans scope (ou `--scope project`) installe sous ./.claude (comportement actuel inchangé)"
+    - "Un appel sans scope (ou `--scope project`) installe sous ./.claude (comportement actuel inchangé) ; ce défaut LEGACY `project` ne co-occurre jamais en prod avec le défaut ensure-deps `user` car le skill /vibeflow-install (Phase 4) passe TOUJOURS un VF_SCOPE explicite (cohérence ID4)"
     - "Un appel `--scope local install <mod>` ajoute les chemins installés au .gitignore (idempotent, sans doublon)"
     - "Le script ne clone plus jamais le repo (aucun `git clone` exécutable dans le code)"
-    - "L'engine peut résoudre la fermeture transitive d'un module avant de l'installer (résolveur intégré)"
+    - "L'engine peut résoudre la fermeture transitive d'un module avant de l'installer (résolveur intégré) ; si le résolveur est ABSENT du cache, l'avertissement est BRUYANT (closure incomplète = install potentiellement cassée)"
   artifacts:
     - path: "_internal/vibeflow-update.sh"
       provides: "Engine scope-aware : TARGET_ROOT résolu, source = cache, gitignore local, résolveur câblé"
       contains: "TARGET_ROOT"
     - path: "_internal/tests/test-vibeflow-update.sh"
-      provides: "Tests isolés (HOME/TARGET_ROOT temporaire) des 5 truths"
+      provides: "Tests isolés (HOME/TARGET_ROOT temporaire) des 5 truths ; T5 copie resolve-deps.sh dans le cache pour exercer RÉELLEMENT le chemin résolveur"
       contains: "mktemp"
   key_links:
     - from: "_internal/vibeflow-update.sh"
@@ -30,7 +30,7 @@ must_haves:
       pattern: "TARGET_ROOT"
     - from: "_internal/vibeflow-update.sh"
       to: "_internal/resolve-deps.sh"
-      via: "appel du résolveur pour la fermeture transitive"
+      via: "appel du résolveur pour la fermeture transitive (résolveur livré dans le cache en prod — Phase 5)"
       pattern: "resolve-deps"
 ---
 
@@ -69,6 +69,22 @@ Output: `vibeflow-update.sh` scope-aware + suppression du clone + résolveur câ
 @dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
 @_internal/tests/test-resolve-deps.sh
 
+<coherence_id4>
+<!-- DÉCISION VERROUILLÉE — ne pas re-débattre. Énoncée ici ET dans 03-02. -->
+
+Le défaut LEGACY de cet engine (VF_SCOPE absent → `project` → `./.claude`) est un fallback pour
+les APPELS DIRECTS uniquement (debug, run manuel, tests). EN PRODUCTION, le skill `/vibeflow-install`
+(Phase 4) passe TOUJOURS un `VF_SCOPE` explicite à l'engine ET à `ensure-deps.sh` (un seul scope
+partout — ID4, spec §3/§8). Donc :
+
+- l'engine (ce script) : défaut-absent = `project` (rétro-compat, comportement actuel `./.claude`) ;
+- ensure-deps.sh (plan 03-02) : défaut-absent = `user` (comportement figé actuel, zéro régression).
+
+Ces deux défauts LEGACY divergent mais NE CO-OCCURRENT JAMAIS en prod : le skill positionne toujours
+`VF_SCOPE`. Il n'y a donc PAS de contradiction entre 03-01 et 03-02. La validation stricte
+(`user|project|local`) rejette tôt toute valeur explicite incohérente.
+</coherence_id4>
+
 <interfaces>
 <!-- Contrats utilisés/produits par ce plan. L'exécuteur s'appuie dessus sans explorer le repo. -->
 
@@ -92,7 +108,11 @@ Cibles d'install codées en dur à rebaser sur $TARGET_ROOT (toutes les occurren
 Mapping scope (spec §3) :
   user           → TARGET_ROOT="$HOME/.claude"
   project | local → TARGET_ROOT="./.claude"   (local ajoute en plus au .gitignore)
-  défaut (aucun) → project (rétro-compat)
+  défaut (aucun) → project (rétro-compat LEGACY — voir <coherence_id4>)
+
+Note packaging (Phase 5 — PLUG-02) : en prod, le résolveur `resolve-deps.sh` DOIT être bundlé dans
+le cache du plugin (`$CACHE_DIR/_internal/resolve-deps.sh`) pour que `resolve_closure` l'exerce
+réellement. Le fallback résolveur-absent (warning bruyant) n'est qu'un garde-fou, pas un mode nominal.
 </interfaces>
 </context>
 
@@ -105,7 +125,10 @@ Mapping scope (spec §3) :
 Rendre l'engine scope-aware et supprimer toute logique de clone (SCOPE-01 + SCOPE-02).
 
 1. Parsing du scope (en tête, après les `set`/variables) :
-   - Lire `VF_SCOPE` (env) avec défaut `project` (rétro-compat — D du milestone).
+   - Lire `VF_SCOPE` (env) avec défaut `project` (rétro-compat LEGACY — voir <coherence_id4>).
+     Documenter EN COMMENTAIRE que ce défaut est un fallback APPEL-DIRECT et que le skill
+     /vibeflow-install (Phase 4) passe toujours VF_SCOPE explicite (cohérence ID4 ; le défaut engine
+     `project` ne co-occurre jamais en prod avec le défaut ensure-deps `user`).
    - Accepter aussi un flag `--scope <user|project|local>` côté Main : le détecter AVANT
      `cmd="$1"` (boucle ou shift simple), retirer `--scope X` des positionnels, et override `VF_SCOPE`.
    - Valider la valeur : `user|project|local` sinon `err "scope invalide : $VF_SCOPE (attendu user|project|local)"`.
@@ -161,8 +184,12 @@ Ajouter le comportement `local` et câbler le résolveur de Phase 2.
    - Localiser `resolve-deps.sh` : il est livré dans le cache (`$CACHE_DIR/_internal/resolve-deps.sh`)
      ou à côté de l'engine (`$(dirname "$0")/resolve-deps.sh`). Prendre le premier existant.
    - Nouvelle fonction `resolve_closure(mod...)` : appelle `VF_MODULES_ROOT="$CACHE_DIR" bash <resolver> "$@"`
-     et renvoie la liste (1/ligne). Si le résolveur est absent, fallback = renvoyer les args tels quels
-     (best-effort, log un warning) — ne JAMAIS faire échouer l'install pour ça.
+     et renvoie la liste (1/ligne).
+   - FALLBACK RÉSOLVEUR-ABSENT (warning 3 du checker — rendre BRUYANT) : si aucun `resolve-deps.sh`
+     n'est trouvé, fallback = renvoyer les args tels quels (best-effort), MAIS loguer un AVERTISSEMENT
+     EXPLICITE via `err` (pas un `log` discret), du type :
+     `err "ATTENTION : résolveur introuvable — fermeture transitive NON calculée. Les dépendances de <mod> ne seront PAS installées ; l'install peut être incomplète/cassée. (Phase 5/PLUG-02 doit bundler resolve-deps.sh dans le cache.)"`.
+     Ne JAMAIS faire échouer l'install pour autant (return des args bruts), mais l'utilisateur DOIT voir le warning.
    - Exposer une option `--with-deps` sur `install` : `install --with-deps <mod>` installe la fermeture
      transitive (chaque module de `resolve_closure <mod>` via `install_module`), en respectant le scope.
      Sans `--with-deps`, comportement actuel (un seul module). Mettre à jour le bloc d'usage en tête.
@@ -171,9 +198,9 @@ Ajouter le comportement `local` et câbler le résolveur de Phase 2.
 3. Ne pas régresser : `install <mod>` seul reste équivalent à aujourd'hui (hors TARGET_ROOT).
   </action>
   <verify>
-    <automated>/bin/bash -c 'bash -n _internal/vibeflow-update.sh && command grep -q "gitignore" _internal/vibeflow-update.sh && command grep -q "resolve-deps" _internal/vibeflow-update.sh && command grep -q -- "--with-deps" _internal/vibeflow-update.sh && echo OK'</automated>
+    <automated>/bin/bash -c 'bash -n _internal/vibeflow-update.sh && command grep -q "gitignore" _internal/vibeflow-update.sh && command grep -q "resolve-deps" _internal/vibeflow-update.sh && command grep -q -- "--with-deps" _internal/vibeflow-update.sh && command grep -qi "résolveur introuvable\|resolveur introuvable\|resolver" _internal/vibeflow-update.sh && echo OK'</automated>
   </verify>
-  <done>`bash -n` OK ; fonction gitignore présente ; résolveur référencé (`resolve-deps`) ; option `--with-deps` câblée. Le `.gitignore` n'est touché qu'en scope `local`.</done>
+  <done>`bash -n` OK ; fonction gitignore présente ; résolveur référencé (`resolve-deps`) ; option `--with-deps` câblée ; warning BRUYANT (`err`) si résolveur absent. Le `.gitignore` n'est touché qu'en scope `local`.</done>
 </task>
 
 <task type="auto" tdd="true">
@@ -184,7 +211,7 @@ Ajouter le comportement `local` et câbler le résolveur de Phase 2.
     - T2 (project défaut) : sans VF_SCOPE, dans un lab mktemp, install → artefacts sous `./.claude/` (comportement actuel) ; rétro-compat dev-orchestrator (agent + references D7 présents).
     - T3 (local → gitignore) : `VF_SCOPE=local install dev-orchestrator` dans un lab → `.gitignore` du lab contient le chemin `.claude/agents/dev-orchestrator.md` ; un 2e run n'ajoute PAS de doublon (idempotent : `grep -c` du chemin == 1).
     - T4 (no clone) : aucune chaîne `git clone`/`git pull` dans le script (asserts statique sur le source).
-    - T5 (résolveur) : `resolve_closure`/`--with-deps validator` installe la fermeture (validator + consolidator + infrastructure-audit) — SKIP propre si les module.json manquent dans le cache.
+    - T5 (résolveur RÉELLEMENT exercé) : copier `_internal/resolve-deps.sh` dans `$CACHE/_internal/resolve-deps.sh` AVANT le run, puis `--with-deps validator` installe la fermeture (validator + consolidator + infrastructure-audit). Le chemin résolveur est ainsi exercé pour de vrai (pas un fallback). SKIP propre seulement si les module.json des modules concernés manquent dans le cache (PAS si le résolveur manque — il est copié).
   </behavior>
   <action>
 Créer `_internal/tests/test-vibeflow-update.sh` sur le pattern du repo (helpers `ok/ko/skip`,
@@ -200,13 +227,30 @@ ISOLATION OBLIGATOIRE — ne JAMAIS toucher au vrai `~/.claude` :
 - `trap 'rm -rf "$LAB"...' EXIT` ou nettoyage explicite par test.
 - Les `bash -c`/grep tournent via `"$GREP"` (binaire système, alias ugrep neutralisé).
 
+T5 — RÉSOLVEUR RÉELLEMENT EXERCÉ (warning 1 du checker) :
+- AVANT le run `--with-deps`, copier le résolveur réel dans le cache de test :
+  `mkdir -p "$CACHE/_internal" && cp _internal/resolve-deps.sh "$CACHE/_internal/resolve-deps.sh"`,
+  de sorte que `resolve_closure` trouve le résolveur DANS le cache et l'exécute (pas le fallback bruyant).
+- Asserter que la fermeture est bien installée (les 3 modules présents sous le TARGET_ROOT du lab).
+- SKIP propre UNIQUEMENT si les `module.json` de validator/consolidator/infrastructure-audit ne sont
+  pas copiables ; ne PAS skip pour résolveur absent (on l'a copié). Jamais de faux négatif.
+- Ajouter un commentaire dans le test : « En prod, Phase 5 (PLUG-02) bundle resolve-deps.sh dans le
+  cache du plugin ; ce test reproduit ce bundling en copiant le résolveur dans $CACHE/_internal/. »
+
 Implémenter T1..T5 ci-dessus. T4 = assert statique (`! "$GREP" -nE 'git clone|git pull' "$INSTALLER"`).
 Mettre des SKIP non bloquants si un module/module.json requis n'est pas copiable, jamais de faux négatif.
+
+GUARD ~/.claude RENFORCÉ (warning 2 du checker) : en plus de l'isolation par HOME=mktemp (vrai
+garde-fou), le test peut consigner un snapshot RÉCURSIF du vrai `~/.claude` :
+`find "$HOME/.claude" -type f 2>/dev/null | wc -l` (ou un checksum) AVANT et APRÈS la suite, et
+asserter l'égalité. Ne PAS se contenter d'un `ls -A | wc -l` top-level. (L'isolation HOME reste la
+défense principale ; ce snapshot est une ceinture+bretelles.) NB : le vrai garde-fou de la VERIFY
+ci-dessous utilise déjà `find -type f` récursif.
   </action>
   <verify>
-    <automated>/bin/bash -c 'bash -n _internal/tests/test-vibeflow-update.sh && HOME_BEFORE=$(ls -A "$HOME/.claude" 2>/dev/null | wc -l); bash _internal/tests/test-vibeflow-update.sh; rc=$?; HOME_AFTER=$(ls -A "$HOME/.claude" 2>/dev/null | wc -l); [ "$HOME_BEFORE" = "$HOME_AFTER" ] && [ "$rc" -eq 0 ] && echo "OK (rc=$rc, ~/.claude intact)"'</automated>
+    <automated>/bin/bash -c 'bash -n _internal/tests/test-vibeflow-update.sh && HOME_BEFORE=$(find "$HOME/.claude" -type f 2>/dev/null | wc -l); bash _internal/tests/test-vibeflow-update.sh; rc=$?; HOME_AFTER=$(find "$HOME/.claude" -type f 2>/dev/null | wc -l); [ "$HOME_BEFORE" = "$HOME_AFTER" ] && [ "$rc" -eq 0 ] && echo "OK (rc=$rc, ~/.claude intact, $HOME_AFTER fichiers récursifs avant=après)"'</automated>
   </verify>
-  <done>Le test passe (exit 0) ET le vrai `~/.claude` est inchangé (même nb d'entrées avant/après). T1..T5 couvrent user/project/local/no-clone/résolveur.</done>
+  <done>Le test passe (exit 0) ET le vrai `~/.claude` est inchangé (même nb de FICHIERS RÉCURSIFS `find -type f` avant/après). T1..T5 couvrent user/project/local/no-clone/résolveur ; T5 exerce RÉELLEMENT le résolveur (copié dans `$CACHE/_internal/`), pas un SKIP.</done>
 </task>
 
 </tasks>
@@ -226,23 +270,27 @@ Mettre des SKIP non bloquants si un module/module.json requis n'est pas copiable
 | T-03-01 | Tampering | `TARGET_ROOT` via `VF_SCOPE` | mitigate | Valider `VF_SCOPE ∈ {user,project,local}` avant résolution ; `err` sinon (Task 1). |
 | T-03-02 | Elevation | écriture `gitignore`/cibles via `$mod` | accept | `$mod` provient de l'appelant local (CLI dev), pas d'une source réseau ; même surface que l'engine actuel. |
 | T-03-03 | Information disclosure | suppression du clone réseau | mitigate | SCOPE-02 supprime tout accès réseau (`git clone`) → réduit la surface ; source = cache local fourni. |
+| T-03-08 | Tampering | résolveur absent → closure silencieusement incomplète | mitigate | Fallback résolveur-absent loggue un warning BRUYANT via `err` (Task 2) ; Phase 5/PLUG-02 doit bundler resolve-deps.sh dans le cache. |
 </threat_model>
 
 <verification>
 - `bash -n` sur l'engine et le test (syntaxe).
 - Aucun `git clone`/`git pull`/`REPO_URL` dans l'engine (`command grep` statique).
-- `test-vibeflow-update.sh` passe (exit 0) et laisse `~/.claude` intact.
+- `test-vibeflow-update.sh` passe (exit 0) et laisse `~/.claude` intact (snapshot `find -type f` récursif avant=après).
 - Rétro-compat : install sans scope dans un lab pose les artefacts sous `./.claude` (T2).
+- T5 exerce réellement le résolveur (copié dans `$CACHE/_internal/`), pas un SKIP.
 </verification>
 
 <success_criteria>
 - SCOPE-01 : `VF_SCOPE=user` cible `$HOME/.claude`, `project`/`local` cible `./.claude` (test T1/T2).
 - SCOPE-02 : plus aucun `git clone` dans l'engine ; source = `VIBEFLOW_CACHE` (test T4).
 - SCOPE-04 : `local` ajoute au `.gitignore` sans doublon (test T3).
-- Résolveur câblé : `--with-deps validator` installe la fermeture transitive (test T5).
-- Le vrai `~/.claude` n'est jamais pollué par les tests.
+- Résolveur câblé : `--with-deps validator` installe la fermeture transitive (test T5, résolveur réellement exercé).
+- Fallback résolveur-absent : warning bruyant (`err`), install jamais bloquée ; flag Phase 5/PLUG-02 (bundle résolveur).
+- Le vrai `~/.claude` n'est jamais pollué par les tests (snapshot récursif avant=après).
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/03-engine-scope-aware/03-01-SUMMARY.md`
 </output>
+</content>

--- a/.planning/phases/03-engine-scope-aware/03-01-SUMMARY.md
+++ b/.planning/phases/03-engine-scope-aware/03-01-SUMMARY.md
@@ -1,0 +1,131 @@
+---
+phase: 03-engine-scope-aware
+plan: 01
+subsystem: infra
+tags: [bash, install-engine, scope-aware, gitignore, dependency-resolver, vibeflow-update]
+
+# Dependency graph
+requires:
+  - phase: 02-manifeste-resolveur
+    provides: resolve-deps.sh (fermeture transitive des `requires` via module.json)
+provides:
+  - "Engine scope-aware vibeflow-update.sh : TARGET_ROOT résolu depuis VF_SCOPE/--scope (user → $HOME/.claude, project|local → ./.claude)"
+  - "Suppression totale du clone/pull git : source = cache local (VIBEFLOW_CACHE), require_cache vérifie l'existence"
+  - "Scope local → ajout idempotent des chemins installés au ./.gitignore"
+  - "Câblage du résolveur Phase 2 : install --with-deps installe la fermeture transitive ; warning bruyant si résolveur absent"
+  - "Test isolé test-vibeflow-update.sh (HOME/cache mktemp) couvrant les 5 truths, ~/.claude jamais pollué"
+affects: [04-skill-vibeflow-install, 05-packaging-plugin]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Parsing --scope <val> avant cmd=$1 (filtrage positionnels, guard set -u tableau vide)"
+    - "Toutes les cibles .claude rebasées sur $TARGET_ROOT ; doc-only docs/<mod>/ laissé hors TARGET_ROOT (cwd projet)"
+    - "Fallback résolveur-absent best-effort + warning BRUYANT (err) sans bloquer l'install"
+    - "Tests isolés HOME=mktemp + snapshot find -type f récursif anti-pollution ~/.claude"
+
+key-files:
+  created:
+    - _internal/tests/test-vibeflow-update.sh
+  modified:
+    - _internal/vibeflow-update.sh
+
+key-decisions:
+  - "Défaut LEGACY engine = project (rétro-compat ./.claude) ; ne co-occurre jamais en prod avec le défaut user de ensure-deps (skill passe toujours VF_SCOPE explicite — cohérence ID4)"
+  - "docs/<mod>/ (doc-only) reste relatif au cwd projet, jamais rebasé sur TARGET_ROOT même en scope user"
+  - "sync devient un no-op explicite plutôt qu'une suppression de commande (rétro-compat appelants)"
+  - "Résolveur localisé d'abord dans $CACHE_DIR/_internal/ (prod, bundle PLUG-02) puis à côté de l'engine (dev)"
+
+patterns-established:
+  - "Validation stricte du scope (user|project|local) avec err précoce sur valeur inconnue"
+  - "gitignore_add_paths idempotent via grep -qxF avant echo, scope local uniquement"
+
+requirements-completed: [SCOPE-01, SCOPE-02, SCOPE-04]
+
+# Metrics
+duration: 3min
+completed: 2026-06-04
+---
+
+# Phase 3 Plan 01: Engine scope-aware Summary
+
+**vibeflow-update.sh devient scope-aware (TARGET_ROOT résolu depuis VF_SCOPE/--scope), supprime tout clone git au profit du cache local, gère le .gitignore en scope local, et câble le résolveur de fermeture transitive de Phase 2.**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-06-04T17:30:22Z
+- **Completed:** 2026-06-04T17:33:37Z
+- **Tasks:** 3
+- **Files modified:** 2 (1 modifié, 1 créé)
+
+## Accomplishments
+- SCOPE-01 : résolution `VF_SCOPE`/`--scope` → `TARGET_ROOT` (user → `$HOME/.claude`, project|local → `./.claude`) avec validation stricte ; toutes les cibles install/uninstall/backup/rollback/status + hook IDX-02 rebasées sur `$TARGET_ROOT`.
+- SCOPE-02 : suppression de `ensure_cache`/`sync_cache`/`REPO_URL` → `require_cache` (vérifie l'existence du cache) ; plus aucun `git clone`/`git pull` ; `sync` devient no-op explicite.
+- SCOPE-04 : `gitignore_add_paths` ajoute les chemins installés au `./.gitignore` en scope `local` uniquement, idempotent.
+- Résolveur câblé : `resolve_closure` + flag `install --with-deps` installent la fermeture transitive ; fallback bruyant (`err`) si résolveur absent, sans bloquer l'install (T-03-08).
+- Test isolé `test-vibeflow-update.sh` : 6 asserts (T1 user / T2 project / T3 local / T4 no-clone / T5 résolveur réellement exercé + garde-fou) tous au vert, `~/.claude` intact (8592 fichiers récursifs avant=après).
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1 + Task 2: Engine scope-aware (TARGET_ROOT, no-clone, gitignore local, résolveur)** - `e99aa7e` (feat)
+2. **Task 3: Test isolé de l'engine scope-aware** - `38114b6` (test)
+
+**Plan metadata:** (commit final docs ci-dessous)
+
+_Note : Tasks 1 et 2 modifient le même fichier (`vibeflow-update.sh`) et ont été implémentées en une passe cohérente, donc regroupées en un seul commit `feat`._
+
+## Files Created/Modified
+- `_internal/vibeflow-update.sh` - Engine scope-aware : parsing `--scope`/`VF_SCOPE`, `TARGET_ROOT`, `require_cache` (plus de git), `resolve_closure`, `--with-deps`, `gitignore_add_paths`.
+- `_internal/tests/test-vibeflow-update.sh` - Suite isolée (HOME/cache mktemp) des 5 truths + garde-fou récursif `~/.claude`.
+
+## Decisions Made
+- Défaut LEGACY engine = `project` (rétro-compat). Documenté en commentaire que le skill /vibeflow-install (Phase 4) passe toujours `VF_SCOPE` explicite → pas de co-occurrence avec le défaut `user` de ensure-deps (cohérence ID4).
+- `docs/<mod>/` (Type 4 doc-only) délibérément laissé hors `TARGET_ROOT` (relatif au cwd projet, ce n'est pas du `.claude`).
+- `sync` transformé en no-op explicite (log) plutôt que supprimé, pour ne pas casser d'éventuels appelants.
+- Résolveur localisé en priorité dans `$CACHE_DIR/_internal/resolve-deps.sh` (chemin de prod bundlé par PLUG-02) puis à côté de l'engine (dev).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] `local` hors fonction dans la branche `install --with-deps`**
+- **Found during:** Task 2 (intégration résolveur)
+- **Issue:** La variable de la branche Main `--with-deps` avait été nommée `local_target` ; au top-level du `case` (hors fonction), le mot-clé `local` aurait pu prêter à confusion / être invalide selon le shell.
+- **Fix:** Renommée en `deps_target` (variable simple, pas de mot-clé `local`).
+- **Files modified:** `_internal/vibeflow-update.sh`
+- **Verification:** `bash -n` OK ; T5 installe la fermeture complète.
+- **Committed in:** `e99aa7e` (commit Task 1+2)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 bug)
+**Impact on plan:** Correction de nommage sans impact fonctionnel ni scope creep. Plan exécuté tel qu'écrit pour le reste.
+
+## Issues Encountered
+None - les 3 tasks ont passé leur verify du premier coup (après la correction de nommage en Task 2).
+
+## TDD Gate Compliance
+Task 3 portait `tdd="true"`. L'implémentation (engine) étant la cible GREEN déjà produite par Tasks 1-2, le test a été écrit puis exécuté contre l'engine existant et passe (6 OK / 0 KO / 0 SKIP). Pas de commit `test` RED séparé avant implémentation car l'engine était la cible du même plan ; documenté ici pour traçabilité.
+
+## User Setup Required
+None - aucune configuration de service externe requise.
+
+## Next Phase Readiness
+- Engine scope-aware prêt à être orchestré par le skill `/vibeflow-install` (Phase 4) : il suffit de lui passer `VF_SCOPE` explicite + un cache préparé.
+- Note packaging (Phase 5 / PLUG-02) : le résolveur `resolve-deps.sh` DOIT être bundlé dans `$CACHE_DIR/_internal/` pour que `resolve_closure` l'exerce réellement en prod (le fallback bruyant n'est qu'un garde-fou).
+
+## Self-Check: PASSED
+
+- FOUND: `_internal/vibeflow-update.sh`
+- FOUND: `_internal/tests/test-vibeflow-update.sh`
+- FOUND: `.planning/phases/03-engine-scope-aware/03-01-SUMMARY.md`
+- FOUND commit: `e99aa7e` (Task 1+2 feat)
+- FOUND commit: `38114b6` (Task 3 test)
+
+---
+*Phase: 03-engine-scope-aware*
+*Completed: 2026-06-04*

--- a/.planning/phases/03-engine-scope-aware/03-02-PLAN.md
+++ b/.planning/phases/03-engine-scope-aware/03-02-PLAN.md
@@ -1,0 +1,179 @@
+---
+phase: 03-engine-scope-aware
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - dev-orchestrator/scripts/ensure-deps.sh
+  - dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
+autonomous: true
+requirements: [SCOPE-03]
+must_haves:
+  truths:
+    - "En dry-run avec VF_SCOPE=user, ensure-deps loggue la commande GSD avec `--global` et Superpowers avec `--scope user`"
+    - "En dry-run avec VF_SCOPE=project (et local), ensure-deps loggue GSD avec `--local` et Superpowers avec `--scope project` (resp. `--scope local`)"
+    - "Sans VF_SCOPE, le comportement par défaut reste l'actuel (GSD `--global`, Superpowers `--scope user`) — rétro-compat"
+    - "ensure-deps reste idempotent (2 runs dry-run consécutifs = exit 0/0) et conserve les fallbacks manuels"
+  artifacts:
+    - path: "dev-orchestrator/scripts/ensure-deps.sh"
+      provides: "Bootstrap scopé via VF_SCOPE (GSD --global/--local, Superpowers --scope ...)"
+      contains: "VF_SCOPE"
+    - path: "dev-orchestrator/scripts/tests/test-dev-orchestrator.sh"
+      provides: "Test T2 étendu : assert des flags scopés en dry-run pour les 3 scopes"
+      contains: "VF_SCOPE"
+  key_links:
+    - from: "dev-orchestrator/scripts/ensure-deps.sh"
+      to: "npx get-shit-done-cc (--global|--local)"
+      via: "flag GSD dérivé de VF_SCOPE"
+      pattern: "global|local"
+    - from: "dev-orchestrator/scripts/ensure-deps.sh"
+      to: "claude plugin install superpowers --scope <s>"
+      via: "scope Superpowers dérivé de VF_SCOPE"
+      pattern: "scope"
+---
+
+<objective>
+Rendre `dev-orchestrator/scripts/ensure-deps.sh` scope-aware via `VF_SCOPE` :
+GSD `user`→`--global`, `project`/`local`→`--local` ; Superpowers
+`claude plugin install … --scope user|project|local`. Conserver l'idempotence, les détections
+et les fallbacks manuels inchangés. Étendre le test du module pour asserter les flags scopés en dry-run.
+
+Purpose: SCOPE-03 — aligner le bootstrap des dépendances (GSD + Superpowers) sur le scope unique
+choisi (spec §3, §8, ID4). Indépendant de l'engine `vibeflow-update.sh` (fichiers disjoints).
+
+Output: `ensure-deps.sh` scopé + test étendu validant les 3 scopes en dry-run, sans réseau.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+# Script à étendre (lire en entier — conserver set -uo pipefail, helpers, dry-run, fallbacks)
+@dev-orchestrator/scripts/ensure-deps.sh
+
+# Test du module à étendre (T2 idempotence — y ajouter les asserts de scope)
+@dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
+
+<interfaces>
+<!-- Contrats du script actuel (à conserver) — l'exécuteur s'appuie dessus. -->
+
+ensure-deps.sh (état actuel) :
+  set -uo pipefail               # PAS de -e (détections via exit non-zéro normaux)
+  VF_ENSURE_DRY_RUN=1 → run_cmd loggue "(dry-run) <cmd>" sur stderr sans exécuter, return 0
+  ensure_gsd()         → run_cmd npx -y get-shit-done-cc@latest --claude --global   (FIGÉ aujourd'hui)
+  ensure_superpowers() → run_cmd claude plugin install superpowers@claude-plugins-official --scope user  (FIGÉ)
+  Fallbacks manuels (Node/npm absent, CLI claude absent, install KO) → message + return 0, jamais d'échec silencieux.
+  detect_gsd / detect_superpowers : inchangées.
+
+Mapping scope (spec §3 / §8) :
+  GSD :         user → --global   ; project|local → --local
+  Superpowers : user → --scope user ; project → --scope project ; local → --scope local
+  défaut (VF_SCOPE absent) → user (rétro-compat : --global / --scope user)
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Scoper ensure-deps.sh via VF_SCOPE (GSD + Superpowers)</name>
+  <files>dev-orchestrator/scripts/ensure-deps.sh</files>
+  <action>
+Introduire `VF_SCOPE` et dériver les flags d'install, sans rien casser d'autre (SCOPE-03).
+
+1. En tête (section Variables) :
+   - `SCOPE="${VF_SCOPE:-user}"` (défaut `user` = rétro-compat avec le comportement figé actuel).
+   - Valider : `user|project|local`, sinon `err "VF_SCOPE invalide : $SCOPE (attendu user|project|local)"`
+     puis `exit 1` (validation stricte, avant tout effet de bord).
+   - Dériver `GSD_SCOPE_FLAG` : `user`→`--global` ; `project|local`→`--local`.
+   - `SUPERPOWERS_SCOPE="$SCOPE"` (Superpowers accepte directement user|project|local).
+   - Documenter dans l'en-tête (`# ...`) la nouvelle variable et le mapping (mettre à jour les
+     commentaires d'usage existants — BOOT-01/02 mentionnaient `--global`/`--scope user` figés).
+
+2. `ensure_gsd` : remplacer `--global` par `"$GSD_SCOPE_FLAG"` dans l'appel `run_cmd npx ...`
+   ET dans le message d'étape manuelle (fallback) pour rester cohérent.
+
+3. `ensure_superpowers` : remplacer `--scope user` par `--scope "$SUPERPOWERS_SCOPE"` dans l'appel
+   direct ET la tentative via marketplace ET le message d'étape manuelle TUI
+   (`/plugin install superpowers@claude-plugins-official` — laisser tel quel pour la TUI car
+   la TUI n'a pas de flag scope, mais ajouter une ligne notant le scope visé).
+
+4. Ne PAS toucher : `set -uo pipefail`, `run_cmd`, `detect_gsd`, `detect_superpowers`, `guard_init`,
+   l'idempotence, ni les chemins de fallback (jamais d'échec silencieux). Le résumé final inchangé.
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'S="dev-orchestrator/scripts/ensure-deps.sh"; bash -n "$S" && command grep -q "VF_SCOPE" "$S" && command grep -q "GSD_SCOPE_FLAG" "$S" && command grep -q "SUPERPOWERS_SCOPE" "$S" && VF_ENSURE_DRY_RUN=1 VF_SCOPE=project bash "$S" 2>&1 | command grep -q -- "--local" && VF_ENSURE_DRY_RUN=1 VF_SCOPE=project bash "$S" 2>&1 | command grep -q -- "--scope project" && echo OK'</automated>
+  </verify>
+  <done>`bash -n` OK ; en dry-run `VF_SCOPE=project` loggue GSD `--local` et Superpowers `--scope project`. Sans VF_SCOPE, loggue `--global` + `--scope user`.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Étendre le test du module — asserts de scope en dry-run (3 scopes)</name>
+  <files>dev-orchestrator/scripts/tests/test-dev-orchestrator.sh</files>
+  <action>
+Étendre la suite existante (ne PAS la réécrire : ajouter des asserts, conserver T1..T6 et le format
+`ok/ko/skip`, `GREP="$(command -v grep)"`, exit 0 si tout passe).
+
+Ajouter un bloc `T2b — ensure-deps scopé (dry-run, sans réseau)` après T2 :
+- Pour chaque scope (`user`, `project`, `local`) : capturer `out=$(VF_ENSURE_DRY_RUN=1 VF_SCOPE=$s
+  bash "$MOD/scripts/ensure-deps.sh" 2>&1)`.
+- Asserts (via `"$GREP"`) :
+  - `user`  → `out` contient `--global` ET `--scope user`.
+  - `project` → `out` contient `--local` ET `--scope project`.
+  - `local`  → `out` contient `--local` ET `--scope local`.
+- Assert rétro-compat : `out=$(VF_ENSURE_DRY_RUN=1 bash ...)` (sans VF_SCOPE) contient `--global`
+  ET `--scope user`.
+- Assert validation : `VF_ENSURE_DRY_RUN=1 VF_SCOPE=bogus bash ... ; [ $? -ne 0 ]` → ok (rejet).
+- `ok`/`ko` par scope, agrégés. Aucun appel réseau (dry-run uniquement).
+
+Tout reste isolé (dry-run ne touche ni `~/.claude` ni le réseau). Ne pas modifier T2 (idempotence).
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'bash -n dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && command grep -q "T2b" dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && bash dev-orchestrator/scripts/tests/test-dev-orchestrator.sh >/tmp/vf_t.log 2>&1; rc=$?; command grep -q "T2b" /tmp/vf_t.log && [ "$rc" -eq 0 ] && echo "OK rc=$rc"'</automated>
+  </verify>
+  <done>La suite passe (exit 0), inclut T2b, et T2b vérifie les flags scopés pour user/project/local + rétro-compat + rejet d'un scope invalide. Aucun réseau touché.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| appelant → ensure-deps (env `VF_SCOPE`) | valeur de scope injectée dans des flags de commandes d'install |
+| ensure-deps → npm/claude CLI (install réseau) | exécution de commandes externes (non-interactif) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-03-04 | Tampering | flag dérivé de `VF_SCOPE` | mitigate | Valider `VF_SCOPE ∈ {user,project,local}` avant tout `run_cmd` ; `err`+`exit 1` sinon (Task 1). |
+| T-03-05 | Denial of Service | install réseau (npx/claude) | accept | Idempotence + détection préalable évitent les installs répétées ; fallback manuel si CLI absente. |
+| T-03-06 | Repudiation | absence de trace en cas d'échec install | mitigate | Comportement existant conservé : tout échec loggue une étape manuelle (jamais d'échec silencieux). |
+</threat_model>
+
+<verification>
+- `bash -n` sur `ensure-deps.sh` et le test.
+- Dry-run par scope : flags `--global`/`--local` et `--scope <s>` corrects.
+- Rétro-compat (sans VF_SCOPE) : `--global` + `--scope user`.
+- Suite `test-dev-orchestrator.sh` verte (exit 0), T2 idempotence préservée, T2b ajouté.
+</verification>
+
+<success_criteria>
+- SCOPE-03 : GSD scopé (`--global`/`--local`) et Superpowers scopé (`--scope user|project|local`) selon `VF_SCOPE`.
+- Idempotence + fallbacks manuels inchangés.
+- Rétro-compat par défaut (`user`).
+- Tests sans réseau ni pollution de `~/.claude` (dry-run).
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-engine-scope-aware/03-02-SUMMARY.md`
+</output>

--- a/.planning/phases/03-engine-scope-aware/03-02-PLAN.md
+++ b/.planning/phases/03-engine-scope-aware/03-02-PLAN.md
@@ -11,17 +11,19 @@ autonomous: true
 requirements: [SCOPE-03]
 must_haves:
   truths:
-    - "En dry-run avec VF_SCOPE=user, ensure-deps loggue la commande GSD avec `--global` et Superpowers avec `--scope user`"
-    - "En dry-run avec VF_SCOPE=project (et local), ensure-deps loggue GSD avec `--local` et Superpowers avec `--scope project` (resp. `--scope local`)"
-    - "Sans VF_SCOPE, le comportement par défaut reste l'actuel (GSD `--global`, Superpowers `--scope user`) — rétro-compat"
-    - "ensure-deps reste idempotent (2 runs dry-run consécutifs = exit 0/0) et conserve les fallbacks manuels"
+    - "En dry-run forcé (VF_ENSURE_FORCE=1) avec VF_SCOPE=user, ensure-deps loggue la commande GSD avec `--global` et Superpowers avec `--scope user` — y compris sur une machine où GSD/Superpowers sont DÉJÀ présents (CI/dev)"
+    - "En dry-run forcé avec VF_SCOPE=project (et local), ensure-deps loggue GSD avec `--local` et Superpowers avec `--scope project` (resp. `--scope local`)"
+    - "Sans VF_SCOPE, le comportement par défaut reste l'actuel (GSD `--global`, Superpowers `--scope user`) — rétro-compat ; ce défaut LEGACY `user` ne co-occurre jamais en prod car le skill /vibeflow-install (Phase 4) passe TOUJOURS un VF_SCOPE explicite (cohérence ID4)"
+    - "ensure-deps reste idempotent en mode normal NON forcé (2 runs dry-run consécutifs sans VF_ENSURE_FORCE = exit 0/0, early-return skip si déps présentes) et conserve les fallbacks manuels"
+    - "VF_ENSURE_FORCE n'a d'effet QU'en dry-run : il court-circuite l'early-return de détection pour loguer la commande scopée, sans jamais rien installer ; hors dry-run il est ignoré (aucune install forcée)"
+    - "VF_SCOPE invalide → err + exit 1 AVANT tout effet de bord (avant main / tout run_cmd)"
   artifacts:
     - path: "dev-orchestrator/scripts/ensure-deps.sh"
-      provides: "Bootstrap scopé via VF_SCOPE (GSD --global/--local, Superpowers --scope ...)"
+      provides: "Bootstrap scopé via VF_SCOPE (GSD --global/--local, Superpowers --scope ...) + VF_ENSURE_FORCE pour dry-run observable"
       contains: "VF_SCOPE"
     - path: "dev-orchestrator/scripts/tests/test-dev-orchestrator.sh"
-      provides: "Test T2 étendu : assert des flags scopés en dry-run pour les 3 scopes"
-      contains: "VF_SCOPE"
+      provides: "Test T2b : assert des flags scopés en dry-run FORCÉ pour les 3 scopes (robuste machine avec déps présentes) + rejet scope invalide"
+      contains: "VF_ENSURE_FORCE"
   key_links:
     - from: "dev-orchestrator/scripts/ensure-deps.sh"
       to: "npx get-shit-done-cc (--global|--local)"
@@ -31,6 +33,10 @@ must_haves:
       to: "claude plugin install superpowers --scope <s>"
       via: "scope Superpowers dérivé de VF_SCOPE"
       pattern: "scope"
+    - from: "dev-orchestrator/scripts/ensure-deps.sh"
+      to: "early-return de détection (ensure_gsd / ensure_superpowers)"
+      via: "VF_ENSURE_FORCE=1 court-circuite l'early-return EN DRY-RUN uniquement"
+      pattern: "VF_ENSURE_FORCE"
 ---
 
 <objective>
@@ -42,7 +48,8 @@ et les fallbacks manuels inchangés. Étendre le test du module pour asserter le
 Purpose: SCOPE-03 — aligner le bootstrap des dépendances (GSD + Superpowers) sur le scope unique
 choisi (spec §3, §8, ID4). Indépendant de l'engine `vibeflow-update.sh` (fichiers disjoints).
 
-Output: `ensure-deps.sh` scopé + test étendu validant les 3 scopes en dry-run, sans réseau.
+Output: `ensure-deps.sh` scopé + `VF_ENSURE_FORCE` (dry-run observable) + test étendu validant les
+3 scopes en dry-run, sans réseau, **robuste sur une machine où GSD/Superpowers sont déjà installés**.
 </objective>
 
 <execution_context>
@@ -62,83 +69,130 @@ Output: `ensure-deps.sh` scopé + test étendu validant les 3 scopes en dry-run,
 # Test du module à étendre (T2 idempotence — y ajouter les asserts de scope)
 @dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
 
+<coherence_id4>
+<!-- DÉCISION VERROUILLÉE — ne pas re-débattre. Énoncée ici ET dans 03-01. -->
+
+Le défaut LEGACY de ce script (VF_SCOPE absent → `user` → `--global` / `--scope user`) est un
+fallback pour les APPELS DIRECTS uniquement (CI, debug, run manuel). EN PRODUCTION, le skill
+`/vibeflow-install` (Phase 4) passe TOUJOURS un `VF_SCOPE` explicite à l'engine ET à ce script
+(un seul scope partout — ID4, spec §3/§8). Donc :
+
+- ce script (ensure-deps.sh) : défaut-absent = `user` (comportement figé actuel, BOOT-01/02, zéro régression) ;
+- l'engine (vibeflow-update.sh, plan 03-01) : défaut-absent = `project`.
+
+Ces deux défauts LEGACY divergent mais NE CO-OCCURRENT JAMAIS en prod : le skill positionne
+toujours `VF_SCOPE`. Il n'y a donc PAS de contradiction entre 03-01 et 03-02. La validation
+stricte (`user|project|local`) garantit qu'une valeur explicite incohérente est rejetée tôt.
+</coherence_id4>
+
 <interfaces>
 <!-- Contrats du script actuel (à conserver) — l'exécuteur s'appuie dessus. -->
 
 ensure-deps.sh (état actuel) :
   set -uo pipefail               # PAS de -e (détections via exit non-zéro normaux)
+  DRY_RUN="${VF_ENSURE_DRY_RUN:-}"
   VF_ENSURE_DRY_RUN=1 → run_cmd loggue "(dry-run) <cmd>" sur stderr sans exécuter, return 0
-  ensure_gsd()         → run_cmd npx -y get-shit-done-cc@latest --claude --global   (FIGÉ aujourd'hui)
-  ensure_superpowers() → run_cmd claude plugin install superpowers@claude-plugins-official --scope user  (FIGÉ)
+  detect_gsd()         → command -v gsd-sdk || [ -f "$GSD_VERSION_FILE" ]
+  detect_superpowers() → claude plugin list | grep superpowers  OU dossier en cache
+  ensure_gsd()         → SI detect_gsd : log "skip" + return 0 (EARLY-RETURN) ;
+                         sinon run_cmd npx -y get-shit-done-cc@latest --claude --global   (FIGÉ aujourd'hui)
+  ensure_superpowers() → SI detect_superpowers : log "skip" + return 0 (EARLY-RETURN) ;
+                         sinon run_cmd claude plugin install superpowers@claude-plugins-official --scope user  (FIGÉ)
   Fallbacks manuels (Node/npm absent, CLI claude absent, install KO) → message + return 0, jamais d'échec silencieux.
-  detect_gsd / detect_superpowers : inchangées.
+  main() { ensure_gsd; ensure_superpowers; guard_init; résumé }
 
 Mapping scope (spec §3 / §8) :
   GSD :         user → --global   ; project|local → --local
   Superpowers : user → --scope user ; project → --scope project ; local → --scope local
-  défaut (VF_SCOPE absent) → user (rétro-compat : --global / --scope user)
+  défaut (VF_SCOPE absent) → user (rétro-compat LEGACY : --global / --scope user — voir coherence_id4)
+
+Problème adressé par VF_ENSURE_FORCE (Blocker checker) :
+  Les EARLY-RETURN "skip" de ensure_gsd/ensure_superpowers court-circuitent run_cmd quand les déps
+  sont déjà détectées. Sur une machine dev/CI où GSD+Superpowers SONT présents, le dry-run ne loggue
+  donc JAMAIS la commande scopée → les asserts qui grep `--local`/`--scope project` échouent À TORT.
+  Fix : VF_ENSURE_FORCE=1 court-circuite l'early-return EN DRY-RUN pour loguer la commande qui SERAIT
+  émise (sans rien installer). En mode normal (non forcé), idempotence inchangée.
 </interfaces>
 </context>
 
 <tasks>
 
 <task type="auto">
-  <name>Task 1: Scoper ensure-deps.sh via VF_SCOPE (GSD + Superpowers)</name>
+  <name>Task 1: Scoper ensure-deps.sh via VF_SCOPE + VF_ENSURE_FORCE (dry-run observable)</name>
   <files>dev-orchestrator/scripts/ensure-deps.sh</files>
   <action>
-Introduire `VF_SCOPE` et dériver les flags d'install, sans rien casser d'autre (SCOPE-03).
+Introduire `VF_SCOPE` + `VF_ENSURE_FORCE` et dériver les flags d'install, sans rien casser d'autre (SCOPE-03).
 
 1. En tête (section Variables) :
-   - `SCOPE="${VF_SCOPE:-user}"` (défaut `user` = rétro-compat avec le comportement figé actuel).
-   - Valider : `user|project|local`, sinon `err "VF_SCOPE invalide : $SCOPE (attendu user|project|local)"`
-     puis `exit 1` (validation stricte, avant tout effet de bord).
+   - `SCOPE="${VF_SCOPE:-user}"` (défaut `user` = rétro-compat LEGACY avec le comportement figé actuel).
+     Documenter EN COMMENTAIRE que ce défaut est un fallback APPEL-DIRECT et que le skill
+     /vibeflow-install (Phase 4) passe toujours VF_SCOPE explicite (cohérence ID4, voir <coherence_id4>).
+   - `FORCE="${VF_ENSURE_FORCE:-}"` (défaut vide). 1 → en DRY-RUN, court-circuite l'early-return de
+     détection pour loguer la commande scopée. Sans effet hors dry-run (jamais d'install forcée).
+   - Valider le scope : `case "$SCOPE" in user|project|local) ;; *) err "VF_SCOPE invalide : $SCOPE (attendu user|project|local)"; exit 1 ;; esac`.
+     Placer cette validation EN TÊTE (section Variables), AVANT toute définition de `main` et AVANT
+     tout appel `run_cmd` / effet de bord. Le `exit 1` doit donc précéder l'appel `main "$@"` final.
    - Dériver `GSD_SCOPE_FLAG` : `user`→`--global` ; `project|local`→`--local`.
    - `SUPERPOWERS_SCOPE="$SCOPE"` (Superpowers accepte directement user|project|local).
-   - Documenter dans l'en-tête (`# ...`) la nouvelle variable et le mapping (mettre à jour les
-     commentaires d'usage existants — BOOT-01/02 mentionnaient `--global`/`--scope user` figés).
+   - Mettre à jour les commentaires d'usage en-tête (BOOT-01/02 mentionnaient `--global`/`--scope user`
+     figés) : documenter VF_SCOPE, VF_ENSURE_FORCE, le mapping, et la note cohérence ID4.
 
-2. `ensure_gsd` : remplacer `--global` par `"$GSD_SCOPE_FLAG"` dans l'appel `run_cmd npx ...`
+2. Court-circuit early-return en dry-run forcé :
+   - Dans `ensure_gsd` : remplacer la garde `if detect_gsd; then log skip; return 0; fi` par une garde
+     qui ne skip QUE si `! ( -n "$DRY_RUN" && -n "$FORCE" )`. Concrètement :
+     `if detect_gsd && ! { [ -n "$DRY_RUN" ] && [ -n "$FORCE" ]; }; then log "GSD déjà présent (skip)."; return 0; fi`
+     → en dry-run forcé, on NE skip PAS : on tombe dans le chemin qui appelle `run_cmd npx ...`, lequel
+     ne fait que loguer (dry-run) sans installer.
+   - Idem dans `ensure_superpowers` pour son early-return `detect_superpowers`.
+   - Important : ce court-circuit ne change RIEN au mode normal (DRY_RUN ou FORCE non positionnés
+     simultanément → comportement strictement identique à aujourd'hui, early-return skip préservé).
+
+3. `ensure_gsd` : remplacer `--global` par `"$GSD_SCOPE_FLAG"` dans l'appel `run_cmd npx ...`
    ET dans le message d'étape manuelle (fallback) pour rester cohérent.
 
-3. `ensure_superpowers` : remplacer `--scope user` par `--scope "$SUPERPOWERS_SCOPE"` dans l'appel
+4. `ensure_superpowers` : remplacer `--scope user` par `--scope "$SUPERPOWERS_SCOPE"` dans l'appel
    direct ET la tentative via marketplace ET le message d'étape manuelle TUI
    (`/plugin install superpowers@claude-plugins-official` — laisser tel quel pour la TUI car
    la TUI n'a pas de flag scope, mais ajouter une ligne notant le scope visé).
 
-4. Ne PAS toucher : `set -uo pipefail`, `run_cmd`, `detect_gsd`, `detect_superpowers`, `guard_init`,
-   l'idempotence, ni les chemins de fallback (jamais d'échec silencieux). Le résumé final inchangé.
+5. Ne PAS toucher : `set -uo pipefail`, `run_cmd`, `detect_gsd`, `detect_superpowers`, `guard_init`,
+   l'idempotence (mode normal), ni les chemins de fallback (jamais d'échec silencieux). Résumé final inchangé.
   </action>
   <verify>
-    <automated>/bin/bash -c 'S="dev-orchestrator/scripts/ensure-deps.sh"; bash -n "$S" && command grep -q "VF_SCOPE" "$S" && command grep -q "GSD_SCOPE_FLAG" "$S" && command grep -q "SUPERPOWERS_SCOPE" "$S" && VF_ENSURE_DRY_RUN=1 VF_SCOPE=project bash "$S" 2>&1 | command grep -q -- "--local" && VF_ENSURE_DRY_RUN=1 VF_SCOPE=project bash "$S" 2>&1 | command grep -q -- "--scope project" && echo OK'</automated>
+    <automated>/bin/bash -c 'S="dev-orchestrator/scripts/ensure-deps.sh"; bash -n "$S" && command grep -q "VF_SCOPE" "$S" && command grep -q "VF_ENSURE_FORCE" "$S" && command grep -q "GSD_SCOPE_FLAG" "$S" && command grep -q "SUPERPOWERS_SCOPE" "$S" && VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 VF_SCOPE=project bash "$S" 2>&1 | command grep -q -- "--local" && VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 VF_SCOPE=project bash "$S" 2>&1 | command grep -q -- "--scope project" && VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 VF_SCOPE=user bash "$S" 2>&1 | command grep -q -- "--global" && ! VF_ENSURE_DRY_RUN=1 VF_SCOPE=bogus bash "$S" >/dev/null 2>&1 && echo OK'</automated>
   </verify>
-  <done>`bash -n` OK ; en dry-run `VF_SCOPE=project` loggue GSD `--local` et Superpowers `--scope project`. Sans VF_SCOPE, loggue `--global` + `--scope user`.</done>
+  <done>`bash -n` OK ; en dry-run FORCÉ `VF_SCOPE=project` loggue GSD `--local` + Superpowers `--scope project` (même si déps présentes), `VF_SCOPE=user` loggue `--global` ; un `VF_SCOPE` invalide sort en exit≠0 (rejet) AVANT effet de bord.</done>
 </task>
 
 <task type="auto">
-  <name>Task 2: Étendre le test du module — asserts de scope en dry-run (3 scopes)</name>
+  <name>Task 2: Étendre le test du module — asserts de scope en dry-run forcé (3 scopes)</name>
   <files>dev-orchestrator/scripts/tests/test-dev-orchestrator.sh</files>
   <action>
 Étendre la suite existante (ne PAS la réécrire : ajouter des asserts, conserver T1..T6 et le format
 `ok/ko/skip`, `GREP="$(command -v grep)"`, exit 0 si tout passe).
 
-Ajouter un bloc `T2b — ensure-deps scopé (dry-run, sans réseau)` après T2 :
-- Pour chaque scope (`user`, `project`, `local`) : capturer `out=$(VF_ENSURE_DRY_RUN=1 VF_SCOPE=$s
-  bash "$MOD/scripts/ensure-deps.sh" 2>&1)`.
+Ajouter un bloc `T2b — ensure-deps scopé (dry-run forcé, sans réseau)` après T2 :
+- Toutes les captures utilisent `VF_ENSURE_FORCE=1` EN PLUS de `VF_ENSURE_DRY_RUN=1`, de sorte que
+  les commandes scopées soient loguées MÊME si GSD/Superpowers sont déjà installés sur la machine
+  (cas dev/CI courant — sinon faux-négatif). Justifier ce flag en commentaire dans le test.
+- Pour chaque scope (`user`, `project`, `local`) :
+  `out=$(VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 VF_SCOPE=$s bash "$MOD/scripts/ensure-deps.sh" 2>&1)`.
 - Asserts (via `"$GREP"`) :
   - `user`  → `out` contient `--global` ET `--scope user`.
   - `project` → `out` contient `--local` ET `--scope project`.
   - `local`  → `out` contient `--local` ET `--scope local`.
-- Assert rétro-compat : `out=$(VF_ENSURE_DRY_RUN=1 bash ...)` (sans VF_SCOPE) contient `--global`
-  ET `--scope user`.
-- Assert validation : `VF_ENSURE_DRY_RUN=1 VF_SCOPE=bogus bash ... ; [ $? -ne 0 ]` → ok (rejet).
-- `ok`/`ko` par scope, agrégés. Aucun appel réseau (dry-run uniquement).
+- Assert rétro-compat : `out=$(VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 bash ...)` (sans VF_SCOPE) contient
+  `--global` ET `--scope user`.
+- Assert validation (scope invalide) : `VF_ENSURE_DRY_RUN=1 VF_SCOPE=bogus bash "$MOD/scripts/ensure-deps.sh" >/dev/null 2>&1; [ $? -ne 0 ]` → ok (rejet, exit≠0 AVANT effet de bord). Pas besoin de FORCE ici (la validation est en tête).
+- `ok`/`ko` par scope, agrégés. Aucun appel réseau (dry-run uniquement, FORCE ne fait que loguer).
 
-Tout reste isolé (dry-run ne touche ni `~/.claude` ni le réseau). Ne pas modifier T2 (idempotence).
+Ne PAS modifier T2 (idempotence) : T2 reste en dry-run NON forcé (sans VF_ENSURE_FORCE) pour valider
+que le mode normal garde son early-return skip. T2b est le seul à utiliser VF_ENSURE_FORCE.
   </action>
   <verify>
-    <automated>/bin/bash -c 'bash -n dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && command grep -q "T2b" dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && bash dev-orchestrator/scripts/tests/test-dev-orchestrator.sh >/tmp/vf_t.log 2>&1; rc=$?; command grep -q "T2b" /tmp/vf_t.log && [ "$rc" -eq 0 ] && echo "OK rc=$rc"'</automated>
+    <automated>/bin/bash -c 'bash -n dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && command grep -q "T2b" dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && command grep -q "VF_ENSURE_FORCE" dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && bash dev-orchestrator/scripts/tests/test-dev-orchestrator.sh >/tmp/vf_t.log 2>&1; rc=$?; command grep -q "T2b" /tmp/vf_t.log && [ "$rc" -eq 0 ] && echo "OK rc=$rc"'</automated>
   </verify>
-  <done>La suite passe (exit 0), inclut T2b, et T2b vérifie les flags scopés pour user/project/local + rétro-compat + rejet d'un scope invalide. Aucun réseau touché.</done>
+  <done>La suite passe (exit 0) sur cette machine (déps présentes), inclut T2b avec VF_ENSURE_FORCE, et T2b vérifie les flags scopés user/project/local + rétro-compat + rejet d'un scope invalide. T2 (idempotence, non forcé) intact. Aucun réseau touché.</done>
 </task>
 
 </tasks>
@@ -148,32 +202,37 @@ Tout reste isolé (dry-run ne touche ni `~/.claude` ni le réseau). Ne pas modif
 
 | Boundary | Description |
 |----------|-------------|
-| appelant → ensure-deps (env `VF_SCOPE`) | valeur de scope injectée dans des flags de commandes d'install |
+| appelant → ensure-deps (env `VF_SCOPE`, `VF_ENSURE_FORCE`) | valeur de scope injectée dans des flags de commandes d'install |
 | ensure-deps → npm/claude CLI (install réseau) | exécution de commandes externes (non-interactif) |
 
 ## STRIDE Threat Register
 
 | Threat ID | Category | Component | Disposition | Mitigation Plan |
 |-----------|----------|-----------|-------------|-----------------|
-| T-03-04 | Tampering | flag dérivé de `VF_SCOPE` | mitigate | Valider `VF_SCOPE ∈ {user,project,local}` avant tout `run_cmd` ; `err`+`exit 1` sinon (Task 1). |
-| T-03-05 | Denial of Service | install réseau (npx/claude) | accept | Idempotence + détection préalable évitent les installs répétées ; fallback manuel si CLI absente. |
+| T-03-04 | Tampering | flag dérivé de `VF_SCOPE` | mitigate | Valider `VF_SCOPE ∈ {user,project,local}` EN TÊTE, `err`+`exit 1` AVANT tout `run_cmd`/`main` (Task 1). |
+| T-03-05 | Denial of Service | install réseau (npx/claude) | accept | Idempotence (mode normal) + détection préalable évitent les installs répétées ; fallback manuel si CLI absente. |
 | T-03-06 | Repudiation | absence de trace en cas d'échec install | mitigate | Comportement existant conservé : tout échec loggue une étape manuelle (jamais d'échec silencieux). |
+| T-03-07 | Elevation | `VF_ENSURE_FORCE` force une install hors scope attendu | mitigate | FORCE n'a d'effet QU'en dry-run (ne fait que loguer via run_cmd) ; hors dry-run il est ignoré → aucune install réelle forcée (Task 1, point 2). |
 </threat_model>
 
 <verification>
 - `bash -n` sur `ensure-deps.sh` et le test.
-- Dry-run par scope : flags `--global`/`--local` et `--scope <s>` corrects.
-- Rétro-compat (sans VF_SCOPE) : `--global` + `--scope user`.
-- Suite `test-dev-orchestrator.sh` verte (exit 0), T2 idempotence préservée, T2b ajouté.
+- Dry-run FORCÉ par scope : flags `--global`/`--local` et `--scope <s>` corrects, même sur machine avec déps présentes.
+- Rétro-compat (sans VF_SCOPE, dry-run forcé) : `--global` + `--scope user`.
+- Scope invalide : exit≠0 avant effet de bord.
+- Suite `test-dev-orchestrator.sh` verte (exit 0), T2 idempotence (non forcée) préservée, T2b ajouté.
 </verification>
 
 <success_criteria>
 - SCOPE-03 : GSD scopé (`--global`/`--local`) et Superpowers scopé (`--scope user|project|local`) selon `VF_SCOPE`.
-- Idempotence + fallbacks manuels inchangés.
-- Rétro-compat par défaut (`user`).
+- Idempotence (mode normal non forcé) + fallbacks manuels inchangés.
+- Rétro-compat par défaut LEGACY (`user`) — ne co-occurre jamais en prod avec le défaut engine `project` (ID4).
+- VF_ENSURE_FORCE rend le dry-run observable sans rien installer (asserts robustes machine avec déps).
 - Tests sans réseau ni pollution de `~/.claude` (dry-run).
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/03-engine-scope-aware/03-02-SUMMARY.md`
 </output>
+</content>
+</invoke>

--- a/.planning/phases/03-engine-scope-aware/03-02-SUMMARY.md
+++ b/.planning/phases/03-engine-scope-aware/03-02-SUMMARY.md
@@ -1,0 +1,88 @@
+---
+phase: 03-engine-scope-aware
+plan: 02
+subsystem: dev-orchestrator/bootstrap
+tags: [scope, ensure-deps, gsd, superpowers, dry-run, SCOPE-03]
+requires:
+  - "dev-orchestrator/scripts/ensure-deps.sh (état BOOT-01/02/03/04)"
+provides:
+  - "ensure-deps.sh scope-aware via VF_SCOPE (GSD --global/--local, Superpowers --scope user|project|local)"
+  - "VF_ENSURE_FORCE : dry-run observable (logue la cmd scopée même si déps présentes, sans installer)"
+  - "Validation stricte VF_SCOPE (user|project|local) en tête (err + exit 1 avant tout effet de bord)"
+  - "T2b : asserts de scope dry-run forcé (3 scopes + rétro-compat + rejet invalide)"
+affects:
+  - "Phase 4 /vibeflow-install : passe toujours VF_SCOPE explicite à ce script (cohérence ID4)"
+tech-stack:
+  added: []
+  patterns:
+    - "Court-circuit conditionnel d'early-return : skip SAUF si (DRY_RUN && FORCE)"
+    - "Validation d'entrée en tête (case) avant définition de main / tout run_cmd"
+    - "Dérivation de flags scope→CLI (mapping spec §3/§8)"
+key-files:
+  created: []
+  modified:
+    - "dev-orchestrator/scripts/ensure-deps.sh"
+    - "dev-orchestrator/scripts/tests/test-dev-orchestrator.sh"
+decisions:
+  - "VF_ENSURE_FORCE n'a d'effet QU'en dry-run (T-03-07) : hors dry-run il est ignoré, jamais d'install forcée"
+  - "Validation VF_SCOPE placée après le helper err mais avant main (err disponible, aucun effet de bord)"
+  - "Défaut LEGACY user conservé (rétro-compat appel-direct) — ne co-occurre jamais en prod avec le défaut engine project (ID4)"
+metrics:
+  duration: "~6 min"
+  completed: 2026-06-04
+  tasks: 2
+  files: 2
+---
+
+# Phase 3 Plan 02 : ensure-deps scope-aware (VF_SCOPE) Summary
+
+Bootstrap `ensure-deps.sh` rendu scope-aware via `VF_SCOPE` (GSD `--global`/`--local`, Superpowers `--scope user|project|local`), avec `VF_ENSURE_FORCE` pour un dry-run observable sur machine où GSD/Superpowers sont déjà installés, validation stricte du scope en tête, et test T2b couvrant les 3 scopes + rétro-compat + rejet d'un scope invalide.
+
+## Ce qui a été fait
+
+### Task 1 — Scoper ensure-deps.sh (commit `2ba5fab`)
+- Variables : `SCOPE="${VF_SCOPE:-user}"`, `FORCE="${VF_ENSURE_FORCE:-}"`.
+- Validation stricte `case "$SCOPE" in user|project|local) ;; *) err … ; exit 1` placée après le helper `err` mais **avant `main`** et tout `run_cmd` (T-03-04, exit 1 avant effet de bord).
+- Dérivation : `GSD_SCOPE_FLAG` (`user`→`--global`, `project|local`→`--local`), `SUPERPOWERS_SCOPE="$SCOPE"`.
+- Court-circuit des early-return : `if detect_X && ! { [ -n "$DRY_RUN" ] && [ -n "$FORCE" ]; }; then skip`. En dry-run forcé on tombe dans le chemin `run_cmd` (logue seulement). Mode normal strictement inchangé.
+- `ensure_gsd` : `--global` → `"$GSD_SCOPE_FLAG"` (appel npx + message manuel).
+- `ensure_superpowers` : `--scope user` → `--scope "$SUPERPOWERS_SCOPE"` (install directe + retry marketplace) ; note du scope visé ajoutée à l'étape manuelle TUI (la TUI n'a pas de flag scope).
+- En-tête d'usage mis à jour (VF_SCOPE, VF_ENSURE_FORCE, mapping, note ID4, SCOPE-03).
+
+### Task 2 — T2b asserts de scope (commit `a01e080`)
+- Bloc `T2b` ajouté après T2, sans toucher T1..T6.
+- Helper `assert_scope` capturant `VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 VF_SCOPE=$s` et grep des flags via `"$GREP"`.
+- Asserts : user→`--global`/`--scope user`, project→`--local`/`--scope project`, local→`--local`/`--scope local`, rétro-compat (sans VF_SCOPE)→`--global`/`--scope user`, rejet `VF_SCOPE=bogus` (exit≠0, sans FORCE).
+- T2 (idempotence, non forcé) intact. Aucun appel réseau (dry-run uniquement).
+
+## Vérification
+
+`bash -n` OK sur les deux fichiers. Suite complète verte sur cette machine (GSD + Superpowers présents) :
+
+```
+12 OK / 0 KO / 0 SKIP
+```
+
+T2b confirme les flags scopés pour les 3 scopes + rétro-compat + rejet du scope invalide ; T1-T6 préservés. Verify Task 1 (`OK`) et verify Task 2 (`OK rc=0`) passés tels qu'écrits dans le plan.
+
+## Threat model
+
+- T-03-04 (Tampering) mitigé : validation `user|project|local` + `err`+`exit 1` avant tout `run_cmd`/`main`.
+- T-03-07 (Elevation) mitigé : `VF_ENSURE_FORCE` n'agit qu'en dry-run (logue via `run_cmd`), aucune install réelle forcée.
+- T-03-05 / T-03-06 (DoS/Repudiation) inchangés : idempotence mode normal + fallbacks manuels conservés.
+
+## Deviations from Plan
+
+None — plan exécuté exactement comme écrit. Détail d'implémentation prévu par le plan : la validation `case` est placée après la définition du helper `err` (qu'elle appelle) tout en restant avant `main` et tout effet de bord, conformément à l'exigence « avant main / tout run_cmd ».
+
+## Known Stubs
+
+Aucun. `ensure-deps.sh` reste fonctionnel (install réelle hors dry-run, fallbacks manuels intacts).
+
+## Self-Check: PASSED
+
+- FOUND: dev-orchestrator/scripts/ensure-deps.sh
+- FOUND: dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
+- FOUND: .planning/phases/03-engine-scope-aware/03-02-SUMMARY.md
+- FOUND commit: 2ba5fab (Task 1)
+- FOUND commit: a01e080 (Task 2)

--- a/.planning/phases/04-skill-vibeflow-install/04-01-PLAN.md
+++ b/.planning/phases/04-skill-vibeflow-install/04-01-PLAN.md
@@ -1,0 +1,257 @@
+---
+phase: 04-skill-vibeflow-install
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - installer/scripts/build-module-catalog.sh
+  - installer/scripts/tests/test-build-module-catalog.sh
+  - installer/SKILL.md
+autonomous: true
+requirements: [INST-01, INST-02, INST-03, INST-04]
+must_haves:
+  truths:
+    - "Le catalogue liste les 8 modules avec leur description issue des module.json"
+    - "Le skill propose un toggle scope (single-select user/project/local) puis un toggle modules (multi-select)"
+    - "Le skill récapitule la fermeture transitive des dépendances avant install"
+    - "Le skill installe au scope choisi en déléguant à vibeflow-update.sh --scope et ensure-deps.sh VF_SCOPE (jamais de réimplémentation)"
+    - "Le skill passe TOUJOURS un VF_SCOPE explicite (cohérence ID4)"
+  artifacts:
+    - path: "installer/scripts/build-module-catalog.sh"
+      provides: "Catalogue nom+description agrégé depuis les module.json"
+      min_lines: 25
+    - path: "installer/scripts/tests/test-build-module-catalog.sh"
+      provides: "Test isolé du catalogue (8 modules, descriptions présentes)"
+      min_lines: 20
+    - path: "installer/SKILL.md"
+      provides: "Skill /vibeflow-install (orchestration UX à toggles)"
+      min_lines: 40
+  key_links:
+    - from: "installer/scripts/build-module-catalog.sh"
+      to: "*/module.json"
+      via: "jq sur le champ .name + .description"
+      pattern: "jq.*\\.name.*\\.description|jq.*description"
+    - from: "installer/SKILL.md"
+      to: "resolve-deps.sh"
+      via: "référence textuelle (auto-résolution déps)"
+      pattern: "resolve-deps"
+    - from: "installer/SKILL.md"
+      to: "vibeflow-update.sh --scope"
+      via: "délégation install scope-aware"
+      pattern: "vibeflow-update.sh.*--scope|--scope.*install"
+    - from: "installer/SKILL.md"
+      to: "ensure-deps.sh"
+      via: "délégation GSD + Superpowers via VF_SCOPE"
+      pattern: "VF_SCOPE.*ensure-deps|ensure-deps.*VF_SCOPE"
+---
+
+<objective>
+Créer le cœur de l'UX d'install : (1) un script `build-module-catalog.sh` qui agrège les 8
+`module.json` en un catalogue nom + description (source des toggles modules), et (2) le skill
+`/vibeflow-install` agent-driven qui décrit la séquence d'UX (toggle scope → toggle modules →
+auto-résolution + récap → install scopée → récap final) en DÉLÉGUANT aux briques déjà livrées
+(`resolve-deps.sh`, `vibeflow-update.sh --scope`, `ensure-deps.sh` via `VF_SCOPE`).
+
+Purpose: Couvre INST-01..04 — l'utilisateur choisit un scope (single-select) et des modules
+(multi-select), voit la fermeture transitive des dépendances récapitulée, puis l'install
+s'effectue au scope choisi pour les modules VibeFlow + GSD + Superpowers, avec un VF_SCOPE
+explicite partout (ID4).
+
+Output:
+- `installer/scripts/build-module-catalog.sh` (+ son test isolé)
+- `installer/SKILL.md` (prose orchestratrice, discipline writing-skills)
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+# Spec — source de vérité (sections 5 skill + 7 manifeste + 3 mapping scopes)
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+# Briques à orchestrer (NE PAS réimplémenter — déléguer)
+@_internal/resolve-deps.sh
+@_internal/vibeflow-update.sh
+@dev-orchestrator/scripts/ensure-deps.sh
+
+# Discipline d'authoring du skill (frontmatter name+description, corps thin orchestrateur)
+@$HOME/.claude/plugins/cache/claude-plugins-official/superpowers/5.1.0/skills/writing-skills/SKILL.md
+
+# Style FR des skills /vf-* existants à calquer
+@dev-orchestrator/skills/vf-init/SKILL.md
+@dev-orchestrator/skills/vf-dev/SKILL.md
+
+<interfaces>
+<!-- Contrats des briques à orchestrer. L'exécuteur s'en sert directement — pas d'exploration. -->
+
+resolve-deps.sh (fermeture transitive) :
+  VF_MODULES_ROOT=<racine modules> bash resolve-deps.sh <module> [<module> ...]
+  → stdout : un module/ligne, trié, dédupliqué (entrées + toutes leurs deps).
+  Ex. `validator` → consolidator\ninfrastructure-audit\nvalidator.
+
+vibeflow-update.sh (engine scope-aware) :
+  VIBEFLOW_CACHE=<cache> ./vibeflow-update.sh --scope <user|project|local> install --with-deps <module>
+  → résout TARGET_ROOT (user→~/.claude, project|local→./.claude), copie depuis le cache,
+    local ajoute aussi au .gitignore. install --with-deps câble déjà le résolveur.
+  Variantes : install <module> | install --all | status.
+
+ensure-deps.sh (GSD + Superpowers scopés) :
+  VF_SCOPE=<user|project|local> ./ensure-deps.sh
+  → GSD : user→--global, project|local→--local ; Superpowers : --scope <même valeur>.
+  Idempotent. VF_ENSURE_DRY_RUN=1 logue sans exécuter.
+
+module.json (8 fichiers, 1 par module à la racine du repo / du cache) :
+  { "name", "version", "type", "description", "requires": [] }
+</interfaces>
+
+<placement_note>
+Tout le composant installeur vit dans un dossier `installer/` à la racine du repo
+(`installer/SKILL.md`, `installer/scripts/`, `installer/hooks/` — ce dernier livré par 04-02).
+La Phase 5 (packaging) bundlera ce dossier dans le plugin. Le skill, une fois installé/bundlé,
+sera invocable comme `/vibeflow-install`.
+</placement_note>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1 : Script build-module-catalog.sh (agrégation des module.json) + test isolé</name>
+  <files>installer/scripts/build-module-catalog.sh, installer/scripts/tests/test-build-module-catalog.sh</files>
+  <action>
+Créer `installer/scripts/build-module-catalog.sh` (conventions bash du repo : shebang
+`#!/usr/bin/env bash`, `set -euo pipefail`, helpers `log()`/`err()` sur stderr).
+
+Comportement : pour chaque sous-dossier de la racine modules contenant un `module.json`,
+émettre sur stdout une ligne `name\tdescription` (ou `name — description`, choisir un séparateur
+stable et le documenter en en-tête). Source = `jq -r` sur `.name` et `.description`. Trier par
+nom pour un diff déterministe. Exclure les dossiers sans `module.json` (ex. `_internal`, `docs`).
+
+Racine des modules surchargeable : `ROOT="${VF_MODULES_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"`
+— le défaut pointe sur la racine repo (où vivent les 8 module.json) ; surchargeable pour les
+fixtures de test (cohérent avec resolve-deps.sh). Ne JAMAIS écrire de nom de module en dur
+(anti-hallucination, comme build-gsd-index.sh) : tout sort des module.json.
+
+Le catalogue est consommé par le skill pour peupler le toggle modules (INST-02). Garder le
+script minimal — c'est une brique de données, pas de l'UX.
+
+Créer `installer/scripts/tests/test-build-module-catalog.sh` (test ISOLÉ, modèle
+test-resolve-deps.sh / convention TESTING.md) :
+- `set -uo pipefail`, compteurs pass/fail, helpers ok/ko.
+- Construire un `mktemp -d` fixture avec 2-3 sous-dossiers contenant des module.json minimaux
+  (name + description + requires=[]) + un dossier SANS module.json, puis exporter
+  `VF_MODULES_ROOT=<fixture>` pour isoler (ne PAS dépendre du cwd réel).
+- Aussi un cas « repo réel » : `VF_MODULES_ROOT=<repo root>` → vérifier que le catalogue
+  liste exactement 8 lignes et que `validator` ET sa description apparaissent.
+- Assertions : (a) sortie triée ; (b) le dossier sans module.json est exclu ; (c) chaque ligne
+  contient une description non vide ; (d) 8 modules sur le repo réel.
+- `grep` robuste sous zsh : invoquer le script via `bash`, et pour compter utiliser
+  `grep -v '^#' | grep -c` (jamais `grep -c` brut sur du contenu commenté), ou
+  `command grep` si besoin.
+- Exit 0 si tout passe, 1 sinon.
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && bash installer/scripts/tests/test-build-module-catalog.sh'</automated>
+  </verify>
+  <done>
+Le test passe (exit 0). `VF_MODULES_ROOT=<repo> bash installer/scripts/build-module-catalog.sh`
+émet 8 lignes triées, chacune avec nom + description non vide ; un dossier sans module.json est
+exclu ; aucun nom de module n'est codé en dur dans le script.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2 : Skill /vibeflow-install (orchestration UX à toggles, discipline writing-skills)</name>
+  <files>installer/SKILL.md</files>
+  <action>
+Créer `installer/SKILL.md` selon la discipline writing-skills (frontmatter YAML `name` +
+`description`, corps thin orchestrateur en français, calque le style des /vf-*).
+
+Frontmatter :
+- `name: vibeflow-install`
+- `description` : commence par « Utiliser quand… », triggers SEULEMENT (pas de résumé du
+  workflow) — ex. premier lancement de VibeFlow après install du plugin, « installe VibeFlow »,
+  « configure les modules », « ajoute un module », « change de scope », re-configuration.
+  Mentionner que le hook SessionStart de 1er lancement (04-02) l'invoque automatiquement.
+
+Corps (prose orchestratrice, PAS de réimplémentation — délègue aux briques de l'<interfaces>) :
+décrire la séquence du skill telle quelle :
+1. **Détection environnement** : GSD/Superpowers présents ? modules déjà installés
+   (`vibeflow-update.sh status`) ? scope existant ?
+2. **Toggle scope (INST-01, single-select)** : user / project / local, via l'UI de questions du
+   terminal (AskUserQuestion / toggles), PAS un TUI bash. Un seul scope choisi (ID4).
+3. **Toggle modules (INST-02, multi-select)** : peupler la liste à partir de
+   `build-module-catalog.sh` (nom + description 1 ligne issus des module.json).
+4. **Auto-résolution + récap (INST-03)** : passer la sélection à `resolve-deps.sh` pour la
+   fermeture transitive, puis RÉCAPITULER explicitement à l'utilisateur (ex. « validator entraîne
+   consolidator + infrastructure-audit ») AVANT toute install.
+5. **Install scopée (INST-04)** : déléguer —
+   - Modules VibeFlow → `vibeflow-update.sh --scope <s> install --with-deps <module>` (ou
+     itérer la fermeture résolue), avec `VIBEFLOW_CACHE` pointant sur le cache du plugin.
+   - GSD + Superpowers → `VF_SCOPE=<s> ensure-deps.sh` (si dev-orchestrator sélectionné, ou sur
+     demande). PASSER TOUJOURS un VF_SCOPE explicite = le scope choisi (cohérence ID4 — citer
+     la décision).
+   - Scope `local` → le .gitignore est géré par l'engine (déjà fait, SCOPE-04) : ne pas le
+     réimplémenter, juste le mentionner.
+6. **Récap final** + prochaines étapes (ex. « dis "aide-moi à dev" pour démarrer »). Reframe en
+   vocabulaire VibeFlow ; ne jamais nommer GSD ni Superpowers à l'utilisateur (cohérent ABS-02 /
+   le style vf-init).
+
+Inclure une note explicite : ce skill est de la PROSE agent-driven ; le routage/UX réel se
+valide en session (comme le first-use), seules les briques déléguées sont testées unitairement.
+Garder le corps concis (cible writing-skills) mais complet sur la séquence et les délégations.
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && f=installer/SKILL.md; command grep -q "^name: vibeflow-install" "$f" && command grep -qi "^description:" "$f" && command grep -q "resolve-deps" "$f" && command grep -Eq "vibeflow-update.sh.*--scope|--scope .*install" "$f" && command grep -Eq "VF_SCOPE.*ensure-deps|ensure-deps.*VF_SCOPE" "$f" && command grep -q "build-module-catalog" "$f" && command grep -qi "ID4" "$f" && echo OK-ALL-REFS'</automated>
+  </verify>
+  <done>
+`installer/SKILL.md` existe avec frontmatter `name: vibeflow-install` + `description` (« Utiliser
+quand… », sans résumé de workflow). Le corps décrit la séquence toggle scope → toggle modules →
+résolution+récap → install scopée → récap, et référence explicitement les 4 briques
+(`build-module-catalog.sh`, `resolve-deps.sh`, `vibeflow-update.sh --scope`, `ensure-deps.sh`
+via `VF_SCOPE`) + cite ID4 (VF_SCOPE explicite). La commande de vérif imprime `OK-ALL-REFS`.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| catalogue ← module.json | Données lues depuis des fichiers du repo/cache (bundlés par le plugin, pas d'input utilisateur arbitraire) |
+| skill → scripts shell | Le skill déclenche des scripts qui écrivent dans ~/.claude ou ./.claude au scope choisi |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-01 | Tampering | build-module-catalog.sh (jq sur module.json) | accept | Source = fichiers bundlés du plugin (pas d'input réseau/utilisateur) ; jq parse du JSON validé en Phase 2 |
+| T-04-02 | Elevation | install au scope user (~/.claude) | mitigate | Le scope est un choix explicite single-select (INST-01) ; l'engine valide VF_SCOPE et rejette toute valeur hors {user,project,local} avant tout effet de bord |
+| T-04-03 | Information disclosure | scope local → .gitignore | accept | Géré par l'engine (SCOPE-04) ; le skill ne réimplémente pas la logique gitignore |
+</threat_model>
+
+<verification>
+- `bash installer/scripts/tests/test-build-module-catalog.sh` → exit 0 (8 modules, descriptions, tri, exclusion).
+- Le skill référence les 4 briques + cite ID4 (vérif grep ci-dessus).
+- Aucune réimplémentation : le skill délègue, le catalogue ne fait qu'agréger.
+</verification>
+
+<success_criteria>
+- INST-01 : le skill décrit un toggle scope single-select (user/project/local).
+- INST-02 : le toggle modules est peuplé depuis le catalogue (nom + description des module.json).
+- INST-03 : la fermeture transitive est récapitulée avant install (via resolve-deps.sh).
+- INST-04 : l'install délègue à vibeflow-update.sh --scope + ensure-deps.sh VF_SCOPE, scope unique partout (ID4).
+- Le catalogue liste les 8 modules et son test isolé passe.
+</success_criteria>
+
+<output>
+Après complétion, créer `.planning/phases/04-skill-vibeflow-install/04-01-SUMMARY.md`
+</output>

--- a/.planning/phases/04-skill-vibeflow-install/04-01-SUMMARY.md
+++ b/.planning/phases/04-skill-vibeflow-install/04-01-SUMMARY.md
@@ -1,0 +1,96 @@
+---
+phase: 04-skill-vibeflow-install
+plan: 01
+subsystem: installer
+tags: [skill, installer, scope, dependencies, jq, writing-skills]
+requires:
+  - "resolve-deps.sh (fermeture transitive — Phase 2)"
+  - "vibeflow-update.sh --scope (engine scope-aware — Phase 3)"
+  - "ensure-deps.sh (bootstrap GSD/Superpowers via VF_SCOPE — Phase 3)"
+  - "les 8 module.json (Phase 2)"
+provides:
+  - "build-module-catalog.sh : catalogue nom+description agrégé depuis les module.json"
+  - "installer/SKILL.md : skill /vibeflow-install orchestrateur à toggles"
+affects:
+  - "Phase 4 plan 02 (hook SessionStart 1er lancement qui invoquera ce skill)"
+  - "Phase 5 (packaging : bundle installer/ + cache dans le plugin)"
+tech-stack:
+  added: []
+  patterns:
+    - "Catalogue data-driven (jq sur module.json, zéro nom en dur)"
+    - "Skill thin orchestrateur (discipline writing-skills : description=triggers, corps=délégation)"
+    - "VF_SCOPE explicite partout (ID4)"
+key-files:
+  created:
+    - installer/scripts/build-module-catalog.sh
+    - installer/scripts/tests/test-build-module-catalog.sh
+    - installer/SKILL.md
+  modified: []
+decisions:
+  - "Séparateur catalogue = TABULATION (name<TAB>description), stable pour cut -f2 et diff déterministe"
+  - "Description du skill = triggers SEULEMENT (writing-skills CSO) — pas de résumé de workflow"
+  - "Skill délègue aux 4 briques, ne réimplémente aucune logique (catalogue, deps, engine, bootstrap)"
+metrics:
+  duration: "~1 min"
+  completed: 2026-06-04
+---
+
+# Phase 04 Plan 01 : Cœur UX d'install (catalogue + skill /vibeflow-install) Summary
+
+Catalogue `build-module-catalog.sh` (agrège les 8 `module.json` en `name<TAB>description` via `jq`, zéro nom en dur) + skill `/vibeflow-install` orchestrateur thin (discipline writing-skills) qui enchaîne toggle scope → toggle modules → résolution+récap des deps → install scopée, en déléguant à `resolve-deps.sh`, `vibeflow-update.sh --scope` et `ensure-deps.sh` (VF_SCOPE explicite partout, ID4).
+
+## Tasks exécutées
+
+| Task | Nom | Commit | Fichiers |
+|------|-----|--------|----------|
+| 1 | build-module-catalog.sh + test isolé | 881e796 | installer/scripts/build-module-catalog.sh, installer/scripts/tests/test-build-module-catalog.sh |
+| 2 | Skill /vibeflow-install (toggles, writing-skills) | ed09cde | installer/SKILL.md |
+
+## Vérification
+
+- **Task 1** — `bash installer/scripts/tests/test-build-module-catalog.sh` → exit 0 (6 OK / 0 KO) :
+  fixture mktemp (tri alpha<zeta, dossier sans module.json exclu, descriptions non vides, 2 modules)
+  + cas repo réel (exactement 8 modules, `validator` présent avec description).
+  Sortie directe vérifiée : 8 lignes triées `name<TAB>description`, aucune description vide.
+- **Task 2** — grep de vérif imprime `OK-ALL-REFS` : frontmatter `name: vibeflow-install` +
+  `description:`, et le corps référence `resolve-deps`, `vibeflow-update.sh --scope`,
+  `VF_SCOPE ... ensure-deps`, `build-module-catalog`, et cite `ID4`. 555 mots.
+
+## Success criteria
+
+- INST-01 : toggle scope single-select (user/project/local) décrit, single-select explicite (ID4).
+- INST-02 : toggle modules peuplé depuis le catalogue (nom + description des module.json).
+- INST-03 : fermeture transitive récapitulée AVANT install (via resolve-deps.sh).
+- INST-04 : install déléguée à `vibeflow-update.sh --scope` + `ensure-deps.sh` via `VF_SCOPE`, scope unique partout.
+- Catalogue liste les 8 modules ; son test isolé passe (exit 0).
+
+## Discipline writing-skills appliquée
+
+- `description` = **triggers uniquement** (premier lancement, « installe VibeFlow », « ajoute un
+  module », « change de scope »…), **sans résumé de workflow** — conforme à la section CSO de
+  writing-skills (« Description = When to Use, NOT What the Skill Does »).
+- `name` en lettres/chiffres/tirets (`vibeflow-install`).
+- Corps = **thin orchestrateur** : prose qui DÉLÈGUE aux briques livrées, ne réimplémente rien
+  (pas de TUI bash, pas de copie, pas de gitignore maison). Cross-références par nom de brique
+  (pas de `@`-links qui force-loadent du contexte).
+- Style FR calqué sur `vf-init` / `vf-dev` (reframe vocabulaire VibeFlow, ne nomme jamais
+  GSD/Superpowers à l'utilisateur).
+
+## Deviations from Plan
+
+None - plan exécuté exactement comme écrit.
+
+## Isolation des tests (zsh)
+
+Test invoqué via `/bin/bash -c` et utilisant `command grep` partout (jamais d'alias zsh hérité).
+Fixtures via `mktemp -d` + `VF_MODULES_ROOT` — aucun test ne dépend du vrai `~/.claude` ni du cwd réel.
+
+## Notes pour la suite
+
+- Le skill suppose `VIBEFLOW_CACHE` / `VF_MODULES_ROOT` pointant sur le **cache du plugin** :
+  c'est Phase 5 (packaging) qui bundlera `installer/` + le cache des modules.
+- Le hook SessionStart de 1er lancement (04-02) invoquera ce skill automatiquement.
+
+## Self-Check: PASSED
+
+Tous les fichiers créés existent ; les 2 commits (881e796, ed09cde) sont présents dans l'historique.

--- a/.planning/phases/04-skill-vibeflow-install/04-02-PLAN.md
+++ b/.planning/phases/04-skill-vibeflow-install/04-02-PLAN.md
@@ -13,18 +13,18 @@ requirements: [INST-05]
 must_haves:
   truths:
     - "Au 1er lancement (marqueur absent), le hook SessionStart émet un additionalContext demandant de lancer l'UX /vibeflow-install"
-    - "Quand un marqueur de 1er lancement est présent, le hook reste silencieux (n'injecte rien)"
+    - "Quand le marqueur de 1er lancement est présent ($HOME/.claude/scripts/.vibeflow-installed user OU ./.claude/scripts/.vibeflow-installed project), le hook reste silencieux (n'injecte rien)"
     - "Le hook suit le modèle Superpowers (hooks.json matcher startup|clear|compact + script émettant hookSpecificOutput.SessionStart.additionalContext)"
     - "Le test est isolé (HOME et marqueurs temporaires, jamais le HOME réel)"
   artifacts:
     - path: "installer/hooks/hooks.json"
-      provides: "Déclaration du hook SessionStart (matcher startup|clear|compact)"
+      provides: "Déclaration du hook SessionStart (matcher startup|clear|compact), JSON parsable"
       contains: "SessionStart"
     - path: "installer/hooks/session-start"
       provides: "Script hook : détecte le marqueur de 1er lancement, émet ou reste silencieux"
       min_lines: 25
     - path: "installer/hooks/tests/test-session-start.sh"
-      provides: "Test isolé : émission au 1er lancement, silence si marqueur présent"
+      provides: "Test isolé : émission au 1er lancement, silence si marqueur user OU project présent"
       min_lines: 25
   key_links:
     - from: "installer/hooks/hooks.json"
@@ -36,9 +36,9 @@ must_haves:
       via: "émission additionalContext quand marqueur absent"
       pattern: "additionalContext"
     - from: "installer/hooks/session-start"
-      to: "marqueur .vibeflow-installed"
-      via: "test d'existence du marqueur (1er lancement)"
-      pattern: "vibeflow-installed"
+      to: "marqueur scripts/.vibeflow-installed (registre engine)"
+      via: "test d'existence du marqueur (1er lancement) — chemin aligné sur vibeflow-update.sh"
+      pattern: "scripts/.vibeflow-installed"
 ---
 
 <objective>
@@ -72,6 +72,13 @@ Output:
 # Spec — sections 5 (auto-lancement ID8) + 2 (décision ID8)
 @docs/superpowers/specs/2026-06-04-install-ux-design.md
 
+# Engine livré — RÉFÉRENCE AUTORITAIRE du chemin de marqueur.
+# vibeflow-update.sh écrit son registre à $TARGET_ROOT/scripts/.vibeflow-installed (lignes ~74/81) :
+#   - scope user            → TARGET_ROOT=$HOME/.claude → $HOME/.claude/scripts/.vibeflow-installed
+#   - scope project|local   → TARGET_ROOT=./.claude     → ./.claude/scripts/.vibeflow-installed
+# Le hook DOIT lire EXACTEMENT ces chemins (sinon il ne trouve jamais le marqueur → ré-émet à chaque session).
+@_internal/vibeflow-update.sh
+
 # Modèle de hook ÉPROUVÉ à calquer (Superpowers)
 @$HOME/.claude/plugins/cache/claude-plugins-official/superpowers/5.1.0/hooks/hooks.json
 @$HOME/.claude/plugins/cache/claude-plugins-official/superpowers/5.1.0/hooks/session-start
@@ -80,9 +87,9 @@ Output:
 @.planning/codebase/TESTING.md
 
 <interfaces>
-<!-- Contrats à respecter — extraits du modèle Superpowers, à adapter. -->
+<!-- Contrats à respecter — extraits du modèle Superpowers + engine vibeflow-update.sh. -->
 
-hooks.json (forme attendue) :
+hooks.json (forme attendue, DOIT être un JSON valide / parsable par jq) :
   { "hooks": { "SessionStart": [ { "matcher": "startup|clear|compact",
     "hooks": [ { "type": "command", "command": "<chemin script via CLAUDE_PLUGIN_ROOT>",
                  "async": false } ] } ] } }
@@ -92,13 +99,16 @@ Sortie JSON du script (format Claude Code) :
                             "additionalContext": "<instruction d'ouvrir l'UX>" } }
   → ÉMISE uniquement au 1er lancement ; sinon le script n'imprime RIEN sur stdout (silencieux).
 
-Marqueur de 1er lancement (spec §5) — 1er lancement = AUCUN marqueur présent :
-  - ~/.claude/.vibeflow-installed  (scope user)
-  - ./.claude/scripts/.vibeflow-installed  (scope project/local — registre posé par l'engine)
+Marqueur de 1er lancement (spec §5, ALIGNÉ sur le registre engine vibeflow-update.sh) —
+1er lancement = AUCUN marqueur présent :
+  - USER_MARKER="${HOME}/.claude/scripts/.vibeflow-installed"   (scope user)
+  - PROJECT_MARKER="./.claude/scripts/.vibeflow-installed"      (scope project/local)
   Si l'UN OU L'AUTRE existe → VibeFlow déjà installé → hook silencieux.
-  Note : l'engine vibeflow-update.sh écrit déjà ./.claude/scripts/.vibeflow-installed (registre
-  des modules installés) ; le hook le réutilise comme marqueur côté project/local. Côté user,
-  le marqueur est ~/.claude/.vibeflow-installed (posé par l'install user).
+  Note critique : l'engine vibeflow-update.sh écrit son registre des modules installés à
+  $TARGET_ROOT/scripts/.vibeflow-installed (user→$HOME/.claude/scripts/, project|local→./.claude/scripts/).
+  Le hook réutilise EXACTEMENT ce registre comme marqueur de 1er lancement — d'où le segment
+  `scripts/` dans les deux chemins. Toute divergence (ex. $HOME/.claude/.vibeflow-installed sans
+  `scripts/`) casse INST-05 en user-scope : aucun marqueur posé → ré-émission à chaque session.
 </interfaces>
 
 <contract_dependency>
@@ -112,19 +122,23 @@ skill `vibeflow-install` / la commande `/vibeflow-install`.
 <tasks>
 
 <task type="auto">
-  <name>Task 1 : hooks.json + script session-start (émet au 1er lancement, sinon silencieux)</name>
+  <name>Task 1 : hooks.json (JSON valide) + script session-start (émet au 1er lancement, sinon silencieux)</name>
   <files>installer/hooks/hooks.json, installer/hooks/session-start</files>
   <action>
 Créer `installer/hooks/hooks.json` sur le modèle Superpowers : un hook `SessionStart`, matcher
 `startup|clear|compact`, un hook `command` `async: false` pointant sur le script `session-start`
 via `${CLAUDE_PLUGIN_ROOT}` (ex. `"${CLAUDE_PLUGIN_ROOT}/hooks/session-start"`). Pas de
-`run-hook.cmd` (spécifique à Superpowers) : pointer directement le script bash.
+`run-hook.cmd` (spécifique à Superpowers) : pointer directement le script bash. Le fichier DOIT
+être un JSON strictement valide (pas de virgule traînante : une virgule traînante passe le grep
+mais fait IGNORER silencieusement le hook).
 
 Créer `installer/hooks/session-start` (script bash exécutable, `set -euo pipefail`) :
-1. Déterminer les chemins de marqueur :
-   - `USER_MARKER="${HOME}/.claude/.vibeflow-installed"`
+1. Déterminer les chemins de marqueur — ALIGNÉS sur le registre de l'engine
+   `vibeflow-update.sh` (`$TARGET_ROOT/scripts/.vibeflow-installed`) :
+   - `USER_MARKER="${HOME}/.claude/scripts/.vibeflow-installed"`
    - `PROJECT_MARKER="./.claude/scripts/.vibeflow-installed"`
-   (HOME surchargeable pour les tests : utiliser `$HOME`, pas un chemin codé en dur.)
+   (HOME surchargeable pour les tests : utiliser `$HOME`, pas un chemin codé en dur. NE PAS
+   omettre le segment `scripts/` — c'est là que l'engine écrit, cf. <interfaces>.)
 2. **1er lancement** = AUCUN des deux marqueurs n'existe. Si l'un existe → VibeFlow déjà installé
    → n'imprimer RIEN sur stdout (silencieux) et `exit 0`.
 3. Si 1er lancement → émettre sur stdout le JSON
@@ -137,22 +151,23 @@ Créer `installer/hooks/session-start` (script bash exécutable, `set -euo pipef
 4. `exit 0` dans tous les cas (un hook ne doit jamais casser le démarrage de session).
 
 Garder le script minimal et robuste : pas de dépendance réseau, pas d'écriture de fichier (le
-hook ne POSE pas le marqueur — c'est l'install via l'engine qui le pose ; le hook ne fait que
-LIRE). `chmod +x installer/hooks/session-start`.
+hook ne POSE pas le marqueur — c'est l'install via l'engine qui le pose à
+`scripts/.vibeflow-installed` ; le hook ne fait que LIRE). `chmod +x installer/hooks/session-start`.
   </action>
   <verify>
-    <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && command grep -q "SessionStart" installer/hooks/hooks.json && command grep -q "startup|clear|compact" installer/hooks/hooks.json && command grep -q "session-start" installer/hooks/hooks.json && command grep -q "additionalContext" installer/hooks/session-start && command grep -q "vibeflow-installed" installer/hooks/session-start && command grep -q "vibeflow-install" installer/hooks/session-start && test -x installer/hooks/session-start && echo OK-HOOK'</automated>
+    <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && jq . installer/hooks/hooks.json >/dev/null && command grep -q "SessionStart" installer/hooks/hooks.json && command grep -q "startup|clear|compact" installer/hooks/hooks.json && command grep -q "session-start" installer/hooks/hooks.json && command grep -q "additionalContext" installer/hooks/session-start && command grep -q "scripts/.vibeflow-installed" installer/hooks/session-start && command grep -q "vibeflow-install" installer/hooks/session-start && test -x installer/hooks/session-start && echo OK-HOOK'</automated>
   </verify>
   <done>
-`installer/hooks/hooks.json` déclare un SessionStart (matcher startup|clear|compact) pointant sur
-le script. `installer/hooks/session-start` est exécutable, lit les deux marqueurs, émet le JSON
-`hookSpecificOutput.SessionStart.additionalContext` nommant `/vibeflow-install` au 1er lancement,
-et reste silencieux sinon. La vérif imprime `OK-HOOK`.
+`installer/hooks/hooks.json` est un JSON VALIDE (`jq .` passe) déclarant un SessionStart (matcher
+startup|clear|compact) pointant sur le script. `installer/hooks/session-start` est exécutable, lit
+les marqueurs `$HOME/.claude/scripts/.vibeflow-installed` (user) et `./.claude/scripts/.vibeflow-installed`
+(project), émet le JSON `hookSpecificOutput.SessionStart.additionalContext` nommant `/vibeflow-install`
+au 1er lancement, et reste silencieux sinon. La vérif imprime `OK-HOOK`.
   </done>
 </task>
 
 <task type="auto">
-  <name>Task 2 : Test isolé du hook (émission au 1er lancement, silence si marqueur)</name>
+  <name>Task 2 : Test isolé du hook (émission au 1er lancement, silence si marqueur user OU project)</name>
   <files>installer/hooks/tests/test-session-start.sh</files>
   <action>
 Créer `installer/hooks/tests/test-session-start.sh` — test ISOLÉ (convention TESTING.md :
@@ -163,15 +178,16 @@ Isolation TOTALE — ne JAMAIS toucher le HOME réel ni le ./.claude réel :
   (`$WORK/proj`). Le test invoque le script ainsi : se placer (sous-shell) dans `$WORK/proj`,
   avec `HOME="$WORK/home"` exporté, et exécuter via `bash <repo>/installer/hooks/session-start`.
 
-Cas de test :
-1. **1er lancement** : aucun marqueur (`$WORK/home/.claude/.vibeflow-installed` absent ET
+Cas de test (chemins de marqueur ALIGNÉS sur l'engine — segment `scripts/`) :
+1. **1er lancement** : aucun marqueur (`$WORK/home/.claude/scripts/.vibeflow-installed` absent ET
    `$WORK/proj/.claude/scripts/.vibeflow-installed` absent) → la sortie stdout contient
-   `additionalContext` ET la chaîne `vibeflow-install`. Optionnel : valider que la sortie est un
-   JSON parsable (`jq . </tmp/out` exit 0) puisque jq est dispo.
-2. **Marqueur user présent** : créer `$WORK/home/.claude/.vibeflow-installed` → la sortie stdout
-   est VIDE (silencieux). Assertion : `[ -z "$out" ]`.
-3. **Marqueur project présent** : (nettoyer le marqueur user) créer
-   `$WORK/proj/.claude/scripts/.vibeflow-installed` → sortie stdout VIDE (silencieux).
+   `additionalContext` ET la chaîne `vibeflow-install`. Valider que la sortie est un JSON parsable
+   (`printf '%s' "$out" | jq . >/dev/null` exit 0) puisque jq est dispo.
+2. **Marqueur user présent** : `mkdir -p $WORK/home/.claude/scripts` puis créer
+   `$WORK/home/.claude/scripts/.vibeflow-installed` (HOME=$WORK/home) → la sortie stdout est
+   VIDE (silencieux). Assertion : `[ -z "$out" ]`. (Ce cas est LE garde-fou du blocker user-scope.)
+3. **Marqueur project présent** : (nettoyer le marqueur user) `mkdir -p $WORK/proj/.claude/scripts`
+   puis créer `$WORK/proj/.claude/scripts/.vibeflow-installed` → sortie stdout VIDE (silencieux).
 4. Dans tous les cas, l'exit code du script = 0.
 
 `grep` robuste sous zsh : invoquer le script via `bash` et compter avec
@@ -181,9 +197,10 @@ Cas de test :
     <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && bash installer/hooks/tests/test-session-start.sh'</automated>
   </verify>
   <done>
-Le test passe (exit 0) en isolation (HOME/cwd temporaires) : émission de `additionalContext`
-nommant `/vibeflow-install` quand aucun marqueur n'existe ; stdout vide quand le marqueur user OU
-project est présent ; exit 0 dans tous les cas. Le HOME réel n'est jamais touché.
+Le test passe (exit 0) en isolation (HOME/cwd temporaires) : émission d'un JSON valide contenant
+`additionalContext` et nommant `/vibeflow-install` quand aucun marqueur n'existe ; stdout VIDE quand
+le marqueur `scripts/.vibeflow-installed` user OU project est présent ; exit 0 dans tous les cas.
+Le HOME réel n'est jamais touché.
   </done>
 </task>
 
@@ -203,21 +220,24 @@ project est présent ; exit 0 dans tous les cas. Le HOME réel n'est jamais touc
 |-----------|----------|-----------|-------------|-----------------|
 | T-04-04 | Denial of service | session-start (démarrage de session) | mitigate | `exit 0` inconditionnel + script minimal sans réseau ni écriture : un hook qui plante ne doit jamais bloquer la session (modèle Superpowers) |
 | T-04-05 | Spoofing | additionalContext injecté dans le prompt | accept | Contenu statique du plugin (pas d'input externe interpolé) ; échappement JSON strict du texte émis |
-| T-04-06 | Tampering | marqueur .vibeflow-installed falsifiable | accept | Faible enjeu : un marqueur posé à tort rend juste le hook silencieux (l'utilisateur peut lancer /vibeflow-install à la main) |
+| T-04-06 | Tampering | marqueur scripts/.vibeflow-installed falsifiable | accept | Faible enjeu : un marqueur posé à tort rend juste le hook silencieux (l'utilisateur peut lancer /vibeflow-install à la main) |
 </threat_model>
 
 <verification>
-- `bash installer/hooks/tests/test-session-start.sh` → exit 0 (émission 1er lancement, silence si marqueur, isolation HOME).
+- `jq . installer/hooks/hooks.json` → exit 0 (hooks.json est un JSON valide, pas de virgule traînante qui ferait ignorer le hook).
+- `bash installer/hooks/tests/test-session-start.sh` → exit 0 (émission 1er lancement, silence si marqueur user OU project présent, isolation HOME).
 - `hooks.json` valide (SessionStart, matcher, pointe le script) ; script exécutable.
 - Note runtime : l'ouverture EFFECTIVE de l'UX par l'agent au démarrage se valide en session réelle (comme le first-use) — ici on valide l'émission/silence de l'additionalContext.
 </verification>
 
 <success_criteria>
-- INST-05 : hook SessionStart + marqueur de 1er lancement → émet l'instruction d'ouvrir /vibeflow-install au 1er lancement, silencieux sinon.
-- Mécanisme calqué sur Superpowers (hooks.json matcher startup|clear|compact + script additionalContext).
-- Test isolé (HOME/cwd temporaires) vert.
+- INST-05 : hook SessionStart + marqueur de 1er lancement (`scripts/.vibeflow-installed`, aligné sur l'engine) → émet l'instruction d'ouvrir /vibeflow-install au 1er lancement, silencieux sinon — y compris en scope user (le cas le plus courant).
+- Mécanisme calqué sur Superpowers (hooks.json matcher startup|clear|compact + script additionalContext) ; hooks.json validé par jq.
+- Test isolé (HOME/cwd temporaires) vert, incluant le cas marqueur user présent → silence.
 </success_criteria>
 
 <output>
 Après complétion, créer `.planning/phases/04-skill-vibeflow-install/04-02-SUMMARY.md`
 </output>
+</content>
+</invoke>

--- a/.planning/phases/04-skill-vibeflow-install/04-02-PLAN.md
+++ b/.planning/phases/04-skill-vibeflow-install/04-02-PLAN.md
@@ -239,5 +239,3 @@ Le HOME réel n'est jamais touché.
 <output>
 Après complétion, créer `.planning/phases/04-skill-vibeflow-install/04-02-SUMMARY.md`
 </output>
-</content>
-</invoke>

--- a/.planning/phases/04-skill-vibeflow-install/04-02-PLAN.md
+++ b/.planning/phases/04-skill-vibeflow-install/04-02-PLAN.md
@@ -1,0 +1,223 @@
+---
+phase: 04-skill-vibeflow-install
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - installer/hooks/hooks.json
+  - installer/hooks/session-start
+  - installer/hooks/tests/test-session-start.sh
+autonomous: true
+requirements: [INST-05]
+must_haves:
+  truths:
+    - "Au 1er lancement (marqueur absent), le hook SessionStart émet un additionalContext demandant de lancer l'UX /vibeflow-install"
+    - "Quand un marqueur de 1er lancement est présent, le hook reste silencieux (n'injecte rien)"
+    - "Le hook suit le modèle Superpowers (hooks.json matcher startup|clear|compact + script émettant hookSpecificOutput.SessionStart.additionalContext)"
+    - "Le test est isolé (HOME et marqueurs temporaires, jamais le HOME réel)"
+  artifacts:
+    - path: "installer/hooks/hooks.json"
+      provides: "Déclaration du hook SessionStart (matcher startup|clear|compact)"
+      contains: "SessionStart"
+    - path: "installer/hooks/session-start"
+      provides: "Script hook : détecte le marqueur de 1er lancement, émet ou reste silencieux"
+      min_lines: 25
+    - path: "installer/hooks/tests/test-session-start.sh"
+      provides: "Test isolé : émission au 1er lancement, silence si marqueur présent"
+      min_lines: 25
+  key_links:
+    - from: "installer/hooks/hooks.json"
+      to: "installer/hooks/session-start"
+      via: "command pointant sur le script via CLAUDE_PLUGIN_ROOT"
+      pattern: "session-start"
+    - from: "installer/hooks/session-start"
+      to: "stdout JSON hookSpecificOutput"
+      via: "émission additionalContext quand marqueur absent"
+      pattern: "additionalContext"
+    - from: "installer/hooks/session-start"
+      to: "marqueur .vibeflow-installed"
+      via: "test d'existence du marqueur (1er lancement)"
+      pattern: "vibeflow-installed"
+---
+
+<objective>
+Livrer l'auto-lancement (INST-05, ID8) : un hook `SessionStart` du plugin qui, au PREMIER
+lancement (marqueur de 1er lancement absent), injecte un `additionalContext` demandant à l'agent
+d'ouvrir l'UX `/vibeflow-install` — et reste TOTALEMENT silencieux une fois VibeFlow installé
+(marqueur présent). Calqué sur le mécanisme éprouvé de Superpowers (`hooks/hooks.json` +
+script `hooks/session-start`).
+
+Purpose: Réduire l'install à 2 commandes (plugin) puis une UX qui s'ouvre seule, sans taper
+`/vibeflow-install`. Le hook ne fait que DÉCLENCHER ; toute la logique d'UX vit dans le skill
+(04-01). Comportement réel en session = validé runtime ; ici on teste l'émission/silence selon
+le marqueur, en isolation totale.
+
+Output:
+- `installer/hooks/hooks.json`
+- `installer/hooks/session-start` (script)
+- `installer/hooks/tests/test-session-start.sh` (test isolé)
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+# Spec — sections 5 (auto-lancement ID8) + 2 (décision ID8)
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+# Modèle de hook ÉPROUVÉ à calquer (Superpowers)
+@$HOME/.claude/plugins/cache/claude-plugins-official/superpowers/5.1.0/hooks/hooks.json
+@$HOME/.claude/plugins/cache/claude-plugins-official/superpowers/5.1.0/hooks/session-start
+
+# Convention de tests isolés (mktemp, trap cleanup, HOME temporaire)
+@.planning/codebase/TESTING.md
+
+<interfaces>
+<!-- Contrats à respecter — extraits du modèle Superpowers, à adapter. -->
+
+hooks.json (forme attendue) :
+  { "hooks": { "SessionStart": [ { "matcher": "startup|clear|compact",
+    "hooks": [ { "type": "command", "command": "<chemin script via CLAUDE_PLUGIN_ROOT>",
+                 "async": false } ] } ] } }
+
+Sortie JSON du script (format Claude Code) :
+  { "hookSpecificOutput": { "hookEventName": "SessionStart",
+                            "additionalContext": "<instruction d'ouvrir l'UX>" } }
+  → ÉMISE uniquement au 1er lancement ; sinon le script n'imprime RIEN sur stdout (silencieux).
+
+Marqueur de 1er lancement (spec §5) — 1er lancement = AUCUN marqueur présent :
+  - ~/.claude/.vibeflow-installed  (scope user)
+  - ./.claude/scripts/.vibeflow-installed  (scope project/local — registre posé par l'engine)
+  Si l'UN OU L'AUTRE existe → VibeFlow déjà installé → hook silencieux.
+  Note : l'engine vibeflow-update.sh écrit déjà ./.claude/scripts/.vibeflow-installed (registre
+  des modules installés) ; le hook le réutilise comme marqueur côté project/local. Côté user,
+  le marqueur est ~/.claude/.vibeflow-installed (posé par l'install user).
+</interfaces>
+
+<contract_dependency>
+Le texte `additionalContext` doit nommer l'UX `/vibeflow-install` (le skill livré par 04-01).
+C'est une référence TEXTUELLE (nom de skill), pas une dépendance de fichier — les deux plans
+ont des fichiers disjoints et tournent en parallèle (wave 1). Utiliser exactement le nom de
+skill `vibeflow-install` / la commande `/vibeflow-install`.
+</contract_dependency>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1 : hooks.json + script session-start (émet au 1er lancement, sinon silencieux)</name>
+  <files>installer/hooks/hooks.json, installer/hooks/session-start</files>
+  <action>
+Créer `installer/hooks/hooks.json` sur le modèle Superpowers : un hook `SessionStart`, matcher
+`startup|clear|compact`, un hook `command` `async: false` pointant sur le script `session-start`
+via `${CLAUDE_PLUGIN_ROOT}` (ex. `"${CLAUDE_PLUGIN_ROOT}/hooks/session-start"`). Pas de
+`run-hook.cmd` (spécifique à Superpowers) : pointer directement le script bash.
+
+Créer `installer/hooks/session-start` (script bash exécutable, `set -euo pipefail`) :
+1. Déterminer les chemins de marqueur :
+   - `USER_MARKER="${HOME}/.claude/.vibeflow-installed"`
+   - `PROJECT_MARKER="./.claude/scripts/.vibeflow-installed"`
+   (HOME surchargeable pour les tests : utiliser `$HOME`, pas un chemin codé en dur.)
+2. **1er lancement** = AUCUN des deux marqueurs n'existe. Si l'un existe → VibeFlow déjà installé
+   → n'imprimer RIEN sur stdout (silencieux) et `exit 0`.
+3. Si 1er lancement → émettre sur stdout le JSON
+   `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<instruction>"}}`
+   où `<instruction>` demande à l'agent d'ouvrir MAINTENANT l'UX d'install VibeFlow
+   (`/vibeflow-install`) : toggle scope + modules, dépendances auto-résolues. Reframe vocabulaire
+   VibeFlow ; ne pas nommer GSD/Superpowers. Échapper correctement la chaîne pour JSON (réutiliser
+   le helper `escape_for_json` du modèle Superpowers : backslash, guillemets, \n, \r, \t) et
+   émettre via `printf` (PAS de heredoc — bug bash 5.3+ documenté dans le modèle Superpowers).
+4. `exit 0` dans tous les cas (un hook ne doit jamais casser le démarrage de session).
+
+Garder le script minimal et robuste : pas de dépendance réseau, pas d'écriture de fichier (le
+hook ne POSE pas le marqueur — c'est l'install via l'engine qui le pose ; le hook ne fait que
+LIRE). `chmod +x installer/hooks/session-start`.
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && command grep -q "SessionStart" installer/hooks/hooks.json && command grep -q "startup|clear|compact" installer/hooks/hooks.json && command grep -q "session-start" installer/hooks/hooks.json && command grep -q "additionalContext" installer/hooks/session-start && command grep -q "vibeflow-installed" installer/hooks/session-start && command grep -q "vibeflow-install" installer/hooks/session-start && test -x installer/hooks/session-start && echo OK-HOOK'</automated>
+  </verify>
+  <done>
+`installer/hooks/hooks.json` déclare un SessionStart (matcher startup|clear|compact) pointant sur
+le script. `installer/hooks/session-start` est exécutable, lit les deux marqueurs, émet le JSON
+`hookSpecificOutput.SessionStart.additionalContext` nommant `/vibeflow-install` au 1er lancement,
+et reste silencieux sinon. La vérif imprime `OK-HOOK`.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2 : Test isolé du hook (émission au 1er lancement, silence si marqueur)</name>
+  <files>installer/hooks/tests/test-session-start.sh</files>
+  <action>
+Créer `installer/hooks/tests/test-session-start.sh` — test ISOLÉ (convention TESTING.md :
+`set -uo pipefail`, compteurs pass/fail, helpers ok/ko, `mktemp -d` + `trap cleanup EXIT`).
+
+Isolation TOTALE — ne JAMAIS toucher le HOME réel ni le ./.claude réel :
+- Créer un `WORK=$(mktemp -d)` ; y créer un faux HOME (`$WORK/home`) et un faux cwd projet
+  (`$WORK/proj`). Le test invoque le script ainsi : se placer (sous-shell) dans `$WORK/proj`,
+  avec `HOME="$WORK/home"` exporté, et exécuter via `bash <repo>/installer/hooks/session-start`.
+
+Cas de test :
+1. **1er lancement** : aucun marqueur (`$WORK/home/.claude/.vibeflow-installed` absent ET
+   `$WORK/proj/.claude/scripts/.vibeflow-installed` absent) → la sortie stdout contient
+   `additionalContext` ET la chaîne `vibeflow-install`. Optionnel : valider que la sortie est un
+   JSON parsable (`jq . </tmp/out` exit 0) puisque jq est dispo.
+2. **Marqueur user présent** : créer `$WORK/home/.claude/.vibeflow-installed` → la sortie stdout
+   est VIDE (silencieux). Assertion : `[ -z "$out" ]`.
+3. **Marqueur project présent** : (nettoyer le marqueur user) créer
+   `$WORK/proj/.claude/scripts/.vibeflow-installed` → sortie stdout VIDE (silencieux).
+4. Dans tous les cas, l'exit code du script = 0.
+
+`grep` robuste sous zsh : invoquer le script via `bash` et compter avec
+`grep -v '^#' | grep -c` ou `command grep`. Exit 0 si tout passe, 1 sinon.
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && bash installer/hooks/tests/test-session-start.sh'</automated>
+  </verify>
+  <done>
+Le test passe (exit 0) en isolation (HOME/cwd temporaires) : émission de `additionalContext`
+nommant `/vibeflow-install` quand aucun marqueur n'existe ; stdout vide quand le marqueur user OU
+project est présent ; exit 0 dans tous les cas. Le HOME réel n'est jamais touché.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| hook → session de Claude Code | Le hook injecte du contexte au démarrage de session (additionalContext) |
+| hook ← marqueurs filesystem | Décision émettre/silence basée sur l'existence de fichiers locaux |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-04 | Denial of service | session-start (démarrage de session) | mitigate | `exit 0` inconditionnel + script minimal sans réseau ni écriture : un hook qui plante ne doit jamais bloquer la session (modèle Superpowers) |
+| T-04-05 | Spoofing | additionalContext injecté dans le prompt | accept | Contenu statique du plugin (pas d'input externe interpolé) ; échappement JSON strict du texte émis |
+| T-04-06 | Tampering | marqueur .vibeflow-installed falsifiable | accept | Faible enjeu : un marqueur posé à tort rend juste le hook silencieux (l'utilisateur peut lancer /vibeflow-install à la main) |
+</threat_model>
+
+<verification>
+- `bash installer/hooks/tests/test-session-start.sh` → exit 0 (émission 1er lancement, silence si marqueur, isolation HOME).
+- `hooks.json` valide (SessionStart, matcher, pointe le script) ; script exécutable.
+- Note runtime : l'ouverture EFFECTIVE de l'UX par l'agent au démarrage se valide en session réelle (comme le first-use) — ici on valide l'émission/silence de l'additionalContext.
+</verification>
+
+<success_criteria>
+- INST-05 : hook SessionStart + marqueur de 1er lancement → émet l'instruction d'ouvrir /vibeflow-install au 1er lancement, silencieux sinon.
+- Mécanisme calqué sur Superpowers (hooks.json matcher startup|clear|compact + script additionalContext).
+- Test isolé (HOME/cwd temporaires) vert.
+</success_criteria>
+
+<output>
+Après complétion, créer `.planning/phases/04-skill-vibeflow-install/04-02-SUMMARY.md`
+</output>

--- a/.planning/phases/04-skill-vibeflow-install/04-02-SUMMARY.md
+++ b/.planning/phases/04-skill-vibeflow-install/04-02-SUMMARY.md
@@ -1,0 +1,88 @@
+---
+phase: 04-skill-vibeflow-install
+plan: 02
+subsystem: infra
+tags: [hooks, session-start, plugin, auto-launch, bash, jq]
+
+requires:
+  - phase: 03 (engine vibeflow-update.sh)
+    provides: "registre des modules installés à $TARGET_ROOT/scripts/.vibeflow-installed — réutilisé comme marqueur de 1er lancement"
+provides:
+  - "Hook SessionStart d'auto-lancement : injecte /vibeflow-install au 1er lancement, silencieux ensuite"
+  - "installer/hooks/hooks.json (déclaration plugin, matcher startup|clear|compact)"
+  - "installer/hooks/session-start (script émetteur/silencieux)"
+  - "Test isolé du hook (HOME/cwd temporaires)"
+affects: [skill vibeflow-install (04-01), packaging plugin]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Hook SessionStart calqué sur Superpowers (hookSpecificOutput.additionalContext, printf au lieu de heredoc)"
+    - "Marqueur de 1er lancement aligné sur le registre de l'engine (segment scripts/) — pas de chemin divergent"
+
+key-files:
+  created:
+    - installer/hooks/hooks.json
+    - installer/hooks/session-start
+    - installer/hooks/tests/test-session-start.sh
+  modified: []
+
+key-decisions:
+  - "Pointer directement le script bash via ${CLAUDE_PLUGIN_ROOT}/hooks/session-start (pas de run-hook.cmd spécifique à Superpowers)"
+  - "Marqueurs USER_MARKER=$HOME/.claude/scripts/.vibeflow-installed ET PROJECT_MARKER=./.claude/scripts/.vibeflow-installed — identiques au registre écrit par vibeflow-update.sh"
+  - "Émission via printf (bug de hang heredoc bash 5.3+), échappement JSON par escape_for_json"
+
+patterns-established:
+  - "Hook lit le marqueur, ne l'écrit jamais (séparation hook=déclencheur / engine=installeur)"
+  - "exit 0 inconditionnel : un hook ne casse jamais le démarrage de session"
+
+metrics:
+  duration: ~5 min
+  completed: 2026-06-04
+  tasks: 2
+  files: 3
+---
+
+# Phase 04 Plan 02 : Hook SessionStart d'auto-lancement /vibeflow-install — Summary
+
+Hook `SessionStart` du plugin VibeFlow qui injecte un `additionalContext` demandant d'ouvrir `/vibeflow-install` au PREMIER lancement (aucun marqueur `scripts/.vibeflow-installed`), et reste totalement silencieux une fois VibeFlow installé. Calqué sur le mécanisme Superpowers, marqueurs alignés sur le registre de l'engine `vibeflow-update.sh`.
+
+## What Was Built
+
+- **`installer/hooks/hooks.json`** — déclare un hook `SessionStart`, matcher `startup|clear|compact`, un hook `command` `async: false` pointant `"${CLAUDE_PLUGIN_ROOT}/hooks/session-start"`. JSON strictement valide (validé par `jq .`, pas de virgule traînante).
+- **`installer/hooks/session-start`** — script bash exécutable (`set -euo pipefail`) :
+  - `USER_MARKER="${HOME}/.claude/scripts/.vibeflow-installed"`, `PROJECT_MARKER="./.claude/scripts/.vibeflow-installed"` (HOME surchargeable, segment `scripts/` aligné sur l'engine) ;
+  - si l'un des marqueurs existe → `exit 0` silencieux (rien sur stdout) ;
+  - sinon émet `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"…/vibeflow-install…"}}` via `printf`, texte échappé par `escape_for_json` ;
+  - `exit 0` inconditionnel.
+- **`installer/hooks/tests/test-session-start.sh`** — test isolé (`mktemp -d` + `trap cleanup`, faux HOME + faux cwd projet). 3 cas, 8 assertions : émission (JSON parsable + `additionalContext` + `vibeflow-install`), silence marqueur user, silence marqueur project ; exit 0 partout.
+
+## Verification
+
+- `jq . installer/hooks/hooks.json` → exit 0 (JSON valide).
+- Verify Task 1 → `OK-HOOK` (SessionStart, matcher, script pointé, additionalContext, marqueur `scripts/.vibeflow-installed`, `vibeflow-install`, script exécutable).
+- Verify Task 2 → `bash installer/hooks/tests/test-session-start.sh` → **PASS : 8 / FAIL : 0**, exit 0.
+- Isolation confirmée : le `~/.claude` réel n'a pas été touché (test écrit uniquement sous `mktemp`).
+- Note runtime : l'ouverture EFFECTIVE de l'UX par l'agent au démarrage se valide en session réelle ; ici on valide l'émission/silence selon le marqueur.
+
+## Threat Model Compliance
+
+- **T-04-04 (DoS)** mitigé : `exit 0` inconditionnel, script minimal sans réseau ni écriture.
+- **T-04-05 (Spoofing)** : contenu statique du plugin, échappement JSON strict (`escape_for_json`).
+- **T-04-06 (Tampering)** : accepté (un marqueur falsifié rend juste le hook silencieux).
+
+## Deviations from Plan
+
+None — plan exécuté exactement comme écrit.
+
+## Known Stubs
+
+None.
+
+## Self-Check: PASSED
+
+- FOUND: installer/hooks/hooks.json
+- FOUND: installer/hooks/session-start (exécutable)
+- FOUND: installer/hooks/tests/test-session-start.sh
+- FOUND commit 144418e (feat 04-02 hook)
+- FOUND commit c341723 (test 04-02)

--- a/.planning/phases/05-packaging-plugin/05-01-PLAN.md
+++ b/.planning/phases/05-packaging-plugin/05-01-PLAN.md
@@ -7,6 +7,7 @@ depends_on: []
 files_modified:
   - .claude-plugin/plugin.json
   - .claude-plugin/marketplace.json
+  - installer/hooks/hooks.json
   - installer/SKILL.md
   - README.md
   - INSTALL.md
@@ -17,6 +18,7 @@ must_haves:
   truths:
     - "Le plugin déclare le skill /vibeflow-install et le hook SessionStart sans charger les modules bundlés comme skills (pas de double-chargement)"
     - "plugin.json et marketplace.json sont des JSON valides et passent claude plugin validate"
+    - "Le hook SessionStart est exécutable au runtime : la commande de hooks.json, une fois ${CLAUDE_PLUGIN_ROOT} résolu sur la racine du repo, pointe sur le script RÉEL (installer/hooks/session-start), qui existe, est exécutable, et émet bien un additionalContext JSON quand le marqueur de 1er lancement est absent — l'auto-lancement (ID8) fonctionne donc réellement"
     - "Le skill /vibeflow-install passe VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} à l'engine, avec fallback dev quand la variable est absente"
     - "Le résolveur _internal/resolve-deps.sh est présent dans le bundle (--with-deps fonctionne après install)"
     - "La doc d'install (README/INSTALL) décrit les 2 commandes plugin + l'auto-lancement, à la place de la procédure clone manuelle"
@@ -27,8 +29,11 @@ must_haves:
     - path: ".claude-plugin/marketplace.json"
       provides: "Entrée marketplace listant le plugin vibeflow (source github picmakpro/vibeflow-os)"
       contains: "\"name\": \"vibeflow\""
+    - path: "installer/hooks/hooks.json"
+      provides: "Déclaration du hook SessionStart pointant le script RÉEL via ${CLAUDE_PLUGIN_ROOT}/installer/hooks/session-start"
+      contains: "installer/hooks/session-start"
     - path: "installer/SKILL.md"
-      provides: "Skill d'install avec câblage VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT}"
+      provides: "Skill d'install avec frontmatter name (vibeflow-install) + câblage VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT}"
       contains: "CLAUDE_PLUGIN_ROOT"
     - path: "README.md"
       provides: "Doc d'install plugin (2 commandes + auto-lancement)"
@@ -42,6 +47,10 @@ must_haves:
       to: "installer/hooks/hooks.json"
       via: "champ hooks"
       pattern: "\"hooks\""
+    - from: "installer/hooks/hooks.json"
+      to: "installer/hooks/session-start"
+      via: "${CLAUDE_PLUGIN_ROOT}/installer/hooks/session-start"
+      pattern: "installer/hooks/session-start"
     - from: "installer/SKILL.md"
       to: "_internal/vibeflow-update.sh"
       via: "VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT}"
@@ -51,15 +60,17 @@ must_haves:
 <objective>
 Transformer le repo `vibeflow-os` en plugin Claude Code installable via marketplace : créer les
 deux manifestes (`.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`) calqués sur
-Superpowers, câbler le cache du skill sur `${CLAUDE_PLUGIN_ROOT}`, et remplacer la doc d'install
+Superpowers, corriger le chemin du hook SessionStart pour qu'il pointe sur le script RÉEL dans le
+bundle, câbler le cache du skill sur `${CLAUDE_PLUGIN_ROOT}`, et remplacer la doc d'install
 clone-manuel par les 2 commandes plugin + auto-lancement.
 
 Purpose: PLUG-01 (manifestes valides) + PLUG-02 (bundle cohérent + cache câblé + doc à jour).
 Couvre le critère de succès Phase 5 #1 : « plugin.json + marketplace.json valides ; le plugin
-bundle modules + skill + engine + manifeste ».
+bundle modules + skill + engine + manifeste » et #2 (auto-lancement opérationnel : hook résolvable).
 
-Output: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `installer/SKILL.md`
-(câblage cache), `README.md` + `INSTALL.md` (doc 2-commandes).
+Output: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
+`installer/hooks/hooks.json` (chemin du script corrigé), `installer/SKILL.md` (câblage cache),
+`README.md` + `INSTALL.md` (doc 2-commandes).
 
 Langue : français (cohérent avec tout le repo).
 </objective>
@@ -98,8 +109,17 @@ CONVENTION PLUGIN — découverte des composants :
   chargent PAS comme skills du plugin. Il ne faut SURTOUT PAS créer de dossier `skills/` à la
   racine ni y déplacer les modules : ils restent des DONNÉES bundlées, copiées au scope par
   l'engine. Le plugin n'expose QUE le skill installer + le hook.
-- `${CLAUDE_PLUGIN_ROOT}` = chemin absolu du dossier d'install du plugin (le cache). C'est ce que
-  l'engine attend dans `VIBEFLOW_CACHE` (les `module.json` y vivent à la racine de chaque module).
+- `${CLAUDE_PLUGIN_ROOT}` = chemin absolu du dossier d'install du plugin (le cache). En contexte
+  plugin il pointe sur la RACINE du repo bundlé. C'est ce que l'engine attend dans `VIBEFLOW_CACHE`
+  (les `module.json` y vivent à la racine de chaque module).
+
+⚠️ CHEMIN DU HOOK (blocker corrigé dans ce plan) : le script du hook vit à
+  `installer/hooks/session-start` (il N'Y A PAS de dossier `hooks/` à la racine du repo). La
+  commande de `installer/hooks/hooks.json` DOIT donc être
+  `"${CLAUDE_PLUGIN_ROOT}/installer/hooks/session-start"` — PAS `${CLAUDE_PLUGIN_ROOT}/hooks/...`
+  qui résout vers un fichier INTROUVABLE et fait échouer SessionStart silencieusement.
+  ⚠️ `claude plugin validate` NE détecte PAS un chemin de script de hook inexistant ni ne charge
+  le skill → un SMOKE TEST runtime explicite est OBLIGATOIRE en plus de `validate` (voir Task 1).
 
 plugin.json — champs (name seul requis ; tout le reste = métadonnées) :
   name, displayName?, version, description, author{name,email?}, homepage, repository, license,
@@ -125,6 +145,13 @@ Engine — câblage cache (déjà en place, NE PAS modifier le .sh) :
   Le skill DOIT donc exporter VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} (et VF_MODULES_ROOT idem) en
   contexte plugin, avec fallback repo en dev (quand CLAUDE_PLUGIN_ROOT est absent).
 
+Hook session-start (déjà livré, NE PAS modifier le script) :
+  Lit les marqueurs `${HOME}/.claude/scripts/.vibeflow-installed` et
+  `./.claude/scripts/.vibeflow-installed`. Si AUCUN n'existe → émet sur stdout un JSON
+  `{ "hookSpecificOutput": { "hookEventName": "SessionStart", "additionalContext": "..." } }`.
+  `HOME` est surchargeable → un smoke test isolé (HOME=mktemp, CWD=mktemp) déclenche l'émission
+  sans toucher le vrai ~/.claude.
+
 VERSION du repo : lire le fichier `VERSION` (actuellement `v2.3.0`). plugin.json `version` =
   semver SANS préfixe `v` (ex. "2.3.0").
 </interfaces>
@@ -133,13 +160,19 @@ VERSION du repo : lire le fichier `VERSION` (actuellement `v2.3.0`). plugin.json
 <tasks>
 
 <task type="auto">
-  <name>Task 1: Créer plugin.json + marketplace.json (PLUG-01)</name>
-  <files>.claude-plugin/plugin.json, .claude-plugin/marketplace.json</files>
+  <name>Task 1: Créer plugin.json + marketplace.json + corriger le chemin du hook (PLUG-01)</name>
+  <files>.claude-plugin/plugin.json, .claude-plugin/marketplace.json, installer/hooks/hooks.json</files>
   <action>
 Créer le dossier `.claude-plugin/` à la racine du repo, puis les deux manifestes calqués sur
-Superpowers (voir &lt;interfaces&gt;).
+Superpowers (voir &lt;interfaces&gt;), ET garantir que le hook SessionStart pointe sur le script RÉEL.
 
-`.claude-plugin/plugin.json` :
+(A) CORRECTION DU CHEMIN DU HOOK (blocker) — `installer/hooks/hooks.json` :
+La commande du hook DOIT être `"${CLAUDE_PLUGIN_ROOT}/installer/hooks/session-start"` (le script
+réel est à `installer/hooks/session-start` ; il n'existe PAS de dossier `hooks/` à la racine du
+repo). Si la valeur actuelle est `${CLAUDE_PLUGIN_ROOT}/hooks/session-start`, la corriger. NE PAS
+modifier le script `installer/hooks/session-start` lui-même.
+
+(B) `.claude-plugin/plugin.json` :
 - `name`: "vibeflow"
 - `displayName`: "VibeFlow"
 - `version`: la version du repo SANS le préfixe `v` — lire le fichier `VERSION` (ex. `v2.3.0` →
@@ -157,7 +190,7 @@ IMPÉRATIF — ne PAS ajouter de dossier `skills/` à la racine ni y déplacer l
 `skills: "./installer"` suffit. Les modules restent des données bundlées (risque double-chargement
 spec §12).
 
-`.claude-plugin/marketplace.json` :
+(C) `.claude-plugin/marketplace.json` :
 - `name`: "vibeflow-os" (id du marketplace)
 - `owner`: { "name": "picmakpro" }
 - `plugins`: [ une seule entrée ] :
@@ -170,12 +203,15 @@ spec §12).
   - `homepage`: "https://github.com/picmakpro/vibeflow-os"
   - `author`: { "name": "picmakpro" }
 
-Écrire les fichiers avec l'outil Write (pas de heredoc).
+Écrire les fichiers avec l'outil Write/Edit (pas de heredoc).
   </action>
   <verify>
-    <automated>jq empty .claude-plugin/plugin.json && jq empty .claude-plugin/marketplace.json && jq -e '.name=="vibeflow" and .skills=="./installer" and (.hooks|test("installer/hooks/hooks.json")) and (.version|test("^[0-9]+\\.[0-9]+\\.[0-9]+"))' .claude-plugin/plugin.json && jq -e '.plugins[0].name=="vibeflow" and .plugins[0].source=="./" and .plugins[0].category=="development"' .claude-plugin/marketplace.json && claude plugin validate . 2>&1 | tail -5</automated>
+    <automated>jq empty .claude-plugin/plugin.json && jq empty .claude-plugin/marketplace.json && jq empty installer/hooks/hooks.json && jq -e '.name=="vibeflow" and .skills=="./installer" and (.hooks|test("installer/hooks/hooks.json")) and (.version|test("^[0-9]+\\.[0-9]+\\.[0-9]+"))' .claude-plugin/plugin.json && jq -e '.plugins[0].name=="vibeflow" and .plugins[0].source=="./" and .plugins[0].category=="development"' .claude-plugin/marketplace.json && claude plugin validate . 2>&1 | tail -5 && \
+SKILL_NAME=$(awk '/^---$/{c++; next} c==1 && /^name:/{print $2; exit}' installer/SKILL.md) && [ -n "$SKILL_NAME" ] && echo "skill name=$SKILL_NAME" && \
+ROOT="$(pwd)" && HOOK_CMD=$(jq -r '.hooks.SessionStart[0].hooks[0].command' installer/hooks/hooks.json) && HOOK_PATH=$(printf '%s' "$HOOK_CMD" | tr -d '"' | sed "s#\${CLAUDE_PLUGIN_ROOT}#$ROOT#g") && echo "resolved hook=$HOOK_PATH" && test -f "$HOOK_PATH" && test -x "$HOOK_PATH" && \
+TMPH=$(mktemp -d) && TMPC=$(mktemp -d) && OUT=$( cd "$TMPC" && HOME="$TMPH" CLAUDE_PROJECT_DIR="$TMPC" "$HOOK_PATH" </dev/null ) ; rm -rf "$TMPH" "$TMPC" ; printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext | test("vibeflow-install")'</automated>
   </verify>
-  <done>Les deux JSON sont valides (jq empty), plugin.json déclare name=vibeflow + skills=./installer + hooks vers installer/hooks/hooks.json + version semver, marketplace.json liste le plugin vibeflow (source ./, category development), et `claude plugin validate .` ne renvoie pas d'erreur (warnings champs inconnus tolérés).</done>
+  <done>Les trois JSON sont valides (jq empty). plugin.json déclare name=vibeflow + skills=./installer + hooks vers installer/hooks/hooks.json + version semver. marketplace.json liste le plugin vibeflow (source ./, category development). `claude plugin validate .` ne renvoie pas d'erreur (warnings champs inconnus tolérés). SMOKE TEST RUNTIME : la commande du hook, ${CLAUDE_PLUGIN_ROOT} résolu sur la racine du repo, pointe sur un fichier qui EXISTE et est EXÉCUTABLE ; exécuté dans un HOME/CWD temporaire (marqueur absent), il émet un JSON parsable dont `additionalContext` contient `vibeflow-install`. Le frontmatter de installer/SKILL.md déclare un `name:` non vide. Le vrai ~/.claude n'est pas touché (mktemp isolé).</done>
 </task>
 
 <task type="auto">
@@ -207,12 +243,13 @@ la section Garde-fous OU dans une note en tête de la section Séquence, sans r�
   `--with-deps` fonctionne après install (réponse au warning Phase 3).
 
 NE PAS modifier les scripts `.sh` (déjà scope-aware et cache-aware). NE PAS réimplémenter de logique :
-le skill reste un orchestrateur thin en prose. Ne pas toucher au frontmatter `name`/`description`.
+le skill reste un orchestrateur thin en prose. Ne pas toucher au frontmatter `name`/`description`
+(le `name: vibeflow-install` est requis pour l'invocation du skill — Task 1 le vérifie).
   </action>
   <verify>
-    <automated>grep -q "CLAUDE_PLUGIN_ROOT" installer/SKILL.md && grep -c "CLAUDE_PLUGIN_ROOT" installer/SKILL.md | { read n; [ "$n" -ge 2 ]; } && grep -qi "fallback\|en dev\|repo" installer/SKILL.md && grep -q "resolve-deps" installer/SKILL.md</automated>
+    <automated>grep -q "CLAUDE_PLUGIN_ROOT" installer/SKILL.md && grep -v '^#' installer/SKILL.md | grep -c "CLAUDE_PLUGIN_ROOT" | { read n; [ "$n" -ge 2 ]; } && grep -qi "fallback\|en dev\|repo" installer/SKILL.md && grep -q "resolve-deps" installer/SKILL.md && awk '/^---$/{c++; next} c==1 && /^name:/{found=1} END{exit !found}' installer/SKILL.md</automated>
   </verify>
-  <done>installer/SKILL.md pose explicitement `VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-…}"` et `VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-…}"` (au moins 2 occurrences de CLAUDE_PLUGIN_ROOT), documente le fallback repo en dev, et mentionne que resolve-deps.sh est bundlé. Les scripts .sh ne sont pas modifiés.</done>
+  <done>installer/SKILL.md pose explicitement `VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-…}"` et `VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-…}"` (au moins 2 occurrences hors-commentaire de CLAUDE_PLUGIN_ROOT), documente le fallback repo en dev, et mentionne que resolve-deps.sh est bundlé. Le frontmatter `name:` reste présent. Les scripts .sh ne sont pas modifiés.</done>
 </task>
 
 <task type="auto">
@@ -268,13 +305,17 @@ Garder la langue française. Écrire avec l'outil Write/Edit.
 | T-05-02 | Elevation | hook SessionStart non-sandboxé | accept | Hook déjà livré/testé Phase 4 (test-session-start.sh) ; lit seulement un marqueur, émet du JSON ; aucune écriture |
 | T-05-03 | Information disclosure | secrets dans le bundle public | mitigate | Checklist pré-public traitée en Plan 02 (audit secrets avant flip) ; ce plan ne rend pas le repo public |
 | T-05-04 | Spoofing | double-chargement skill plugin vs skills copiés | mitigate | Modules NON sous `skills/` ; plugin n'expose que `installer/` via champ `skills` (risque spec §12 neutralisé) |
+| T-05-08 | Denial of service | chemin du hook cassé → SessionStart échoue silencieusement → auto-lancement (ID8) mort | mitigate | Chemin corrigé vers le script RÉEL (`installer/hooks/session-start`) + SMOKE TEST runtime (existence + exécutabilité + émission additionalContext, isolé mktemp) au-delà de `claude plugin validate` qui ne détecte pas un script de hook inexistant |
 </threat_model>
 
 <verification>
-- `jq empty` passe sur les deux manifestes ; `claude plugin validate .` sans erreur.
+- `jq empty` passe sur les deux manifestes + le hooks.json ; `claude plugin validate .` sans erreur.
 - plugin.json : name=vibeflow, version semver, skills=./installer, hooks→installer/hooks/hooks.json.
 - marketplace.json : entrée vibeflow, source "./", category development.
-- installer/SKILL.md : VIBEFLOW_CACHE + VF_MODULES_ROOT câblés sur ${CLAUDE_PLUGIN_ROOT} + fallback dev.
+- hooks.json : commande = `${CLAUDE_PLUGIN_ROOT}/installer/hooks/session-start` ; smoke test runtime
+  (script existe + exécutable + émet additionalContext en HOME/CWD temporaire) passe.
+- installer/SKILL.md : frontmatter `name:` présent ; VIBEFLOW_CACHE + VF_MODULES_ROOT câblés sur
+  ${CLAUDE_PLUGIN_ROOT} + fallback dev.
 - _internal/resolve-deps.sh présent dans le repo (bundle) → `ls _internal/resolve-deps.sh`.
 - README.md + INSTALL.md : 2 commandes plugin + auto-lancement, plus de clone manuel.
 - Aucun dossier `skills/` créé à la racine (pas de double-chargement).
@@ -282,12 +323,13 @@ Garder la langue française. Écrire avec l'outil Write/Edit.
 
 <success_criteria>
 - PLUG-01 : `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` valides, déclarant
-  skill + hook par la convention plugin.
+  skill + hook par la convention plugin ; hook SessionStart résolvable au runtime (auto-lancement réel).
 - PLUG-02 : bundle cohérent (modules + skill + engine + manifeste + résolveur présents), cache
   câblé sur `${CLAUDE_PLUGIN_ROOT}` (fallback dev), doc d'install 2-commandes + auto-lancement.
-- Critère de succès Phase 5 #1 satisfait.
+- Critère de succès Phase 5 #1 satisfait ; auto-lancement (critère #2) opérationnel côté runtime hook.
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/05-packaging-plugin/05-01-SUMMARY.md`
+</output>
 </output>

--- a/.planning/phases/05-packaging-plugin/05-01-PLAN.md
+++ b/.planning/phases/05-packaging-plugin/05-01-PLAN.md
@@ -1,0 +1,293 @@
+---
+phase: 05-packaging-plugin
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .claude-plugin/plugin.json
+  - .claude-plugin/marketplace.json
+  - installer/SKILL.md
+  - README.md
+  - INSTALL.md
+autonomous: true
+requirements: [PLUG-01, PLUG-02]
+
+must_haves:
+  truths:
+    - "Le plugin déclare le skill /vibeflow-install et le hook SessionStart sans charger les modules bundlés comme skills (pas de double-chargement)"
+    - "plugin.json et marketplace.json sont des JSON valides et passent claude plugin validate"
+    - "Le skill /vibeflow-install passe VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} à l'engine, avec fallback dev quand la variable est absente"
+    - "Le résolveur _internal/resolve-deps.sh est présent dans le bundle (--with-deps fonctionne après install)"
+    - "La doc d'install (README/INSTALL) décrit les 2 commandes plugin + l'auto-lancement, à la place de la procédure clone manuelle"
+  artifacts:
+    - path: ".claude-plugin/plugin.json"
+      provides: "Manifeste plugin (name vibeflow, version, skills installer, hooks installer/hooks/hooks.json)"
+      contains: "\"name\": \"vibeflow\""
+    - path: ".claude-plugin/marketplace.json"
+      provides: "Entrée marketplace listant le plugin vibeflow (source github picmakpro/vibeflow-os)"
+      contains: "\"name\": \"vibeflow\""
+    - path: "installer/SKILL.md"
+      provides: "Skill d'install avec câblage VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT}"
+      contains: "CLAUDE_PLUGIN_ROOT"
+    - path: "README.md"
+      provides: "Doc d'install plugin (2 commandes + auto-lancement)"
+      contains: "claude plugin marketplace add picmakpro/vibeflow-os"
+  key_links:
+    - from: ".claude-plugin/plugin.json"
+      to: "installer/SKILL.md"
+      via: "champ skills (./installer)"
+      pattern: "\"skills\""
+    - from: ".claude-plugin/plugin.json"
+      to: "installer/hooks/hooks.json"
+      via: "champ hooks"
+      pattern: "\"hooks\""
+    - from: "installer/SKILL.md"
+      to: "_internal/vibeflow-update.sh"
+      via: "VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT}"
+      pattern: "CLAUDE_PLUGIN_ROOT"
+---
+
+<objective>
+Transformer le repo `vibeflow-os` en plugin Claude Code installable via marketplace : créer les
+deux manifestes (`.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`) calqués sur
+Superpowers, câbler le cache du skill sur `${CLAUDE_PLUGIN_ROOT}`, et remplacer la doc d'install
+clone-manuel par les 2 commandes plugin + auto-lancement.
+
+Purpose: PLUG-01 (manifestes valides) + PLUG-02 (bundle cohérent + cache câblé + doc à jour).
+Couvre le critère de succès Phase 5 #1 : « plugin.json + marketplace.json valides ; le plugin
+bundle modules + skill + engine + manifeste ».
+
+Output: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `installer/SKILL.md`
+(câblage cache), `README.md` + `INSTALL.md` (doc 2-commandes).
+
+Langue : français (cohérent avec tout le repo).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+# Briques déjà livrées (le plugin les bundle — NE PAS les ré-implémenter)
+@installer/SKILL.md
+@installer/hooks/hooks.json
+@installer/hooks/session-start
+@_internal/vibeflow-update.sh
+
+<interfaces>
+<!-- Convention plugin Claude Code (source : docs.claude.com/en/plugins-reference). -->
+<!-- L'executor utilise ces faits directement — pas d'exploration nécessaire. -->
+
+CONVENTION PLUGIN — découverte des composants :
+- Skills : le dossier `skills/` à la racine est TOUJOURS scanné ; le champ `skills` du plugin.json
+  AJOUTE des dossiers en plus (string|array). Un dossier qui contient un `SKILL.md` direct (ex.
+  `"skills": ["./installer"]`) charge ce skill ; le nom d'invocation = le champ `name` du
+  frontmatter du SKILL.md (ici `vibeflow-install`), sinon le basename du dossier.
+- Hooks : `hooks/hooks.json` à la racine, OU champ `hooks` du plugin.json pointant un chemin
+  custom (ex. `"./installer/hooks/hooks.json"`).
+- ⚠️ DOUBLE-CHARGEMENT (risque spec §12) : les modules bundlés (`consolidator/`, `validator/`, …)
+  ont chacun un `SKILL.md`/`AGENT.md` à leur racine MAIS ne sont PAS sous `skills/` → ils ne se
+  chargent PAS comme skills du plugin. Il ne faut SURTOUT PAS créer de dossier `skills/` à la
+  racine ni y déplacer les modules : ils restent des DONNÉES bundlées, copiées au scope par
+  l'engine. Le plugin n'expose QUE le skill installer + le hook.
+- `${CLAUDE_PLUGIN_ROOT}` = chemin absolu du dossier d'install du plugin (le cache). C'est ce que
+  l'engine attend dans `VIBEFLOW_CACHE` (les `module.json` y vivent à la racine de chaque module).
+
+plugin.json — champs (name seul requis ; tout le reste = métadonnées) :
+  name, displayName?, version, description, author{name,email?}, homepage, repository, license,
+  keywords[], skills(string|array), hooks(string|array|object).
+  `claude plugin validate` signale les champs inconnus en warnings (pas erreurs) sauf `--strict`.
+
+marketplace.json — schéma :
+  { "name": <id-marketplace>, "owner": {"name": ..., "email"?}, "plugins": [ <entrée> ] }
+  Entrée plugin (min : name + source) : peut reprendre tout champ du manifeste (description,
+  version, author, …) + champs marketplace : source, category, tags, strict.
+  source github : { "source": "github", "repo": "owner/repo" }.
+  source relative "./" : autorisée car les users ajoutent le marketplace via GitHub (modèle
+  Superpowers : "source": "./" car le repo EST le plugin ET héberge le marketplace).
+
+Manifeste Superpowers (gabarit ÉPROUVÉ) — plugin.json :
+  { name, description, version, author{name,email}, homepage, repository, license, keywords[] }
+  marketplace.json :
+  { name, description, owner{name,email}, plugins:[{ name, description, version, source:"./", author }] }
+
+Engine — câblage cache (déjà en place, NE PAS modifier le .sh) :
+  _internal/vibeflow-update.sh : `CACHE_DIR="${VIBEFLOW_CACHE:-.vibeflow-cache}"` → SEULE source.
+  build-module-catalog.sh / resolve-deps.sh : racine modules via `VF_MODULES_ROOT`.
+  Le skill DOIT donc exporter VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} (et VF_MODULES_ROOT idem) en
+  contexte plugin, avec fallback repo en dev (quand CLAUDE_PLUGIN_ROOT est absent).
+
+VERSION du repo : lire le fichier `VERSION` (actuellement `v2.3.0`). plugin.json `version` =
+  semver SANS préfixe `v` (ex. "2.3.0").
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Créer plugin.json + marketplace.json (PLUG-01)</name>
+  <files>.claude-plugin/plugin.json, .claude-plugin/marketplace.json</files>
+  <action>
+Créer le dossier `.claude-plugin/` à la racine du repo, puis les deux manifestes calqués sur
+Superpowers (voir &lt;interfaces&gt;).
+
+`.claude-plugin/plugin.json` :
+- `name`: "vibeflow"
+- `displayName`: "VibeFlow"
+- `version`: la version du repo SANS le préfixe `v` — lire le fichier `VERSION` (ex. `v2.3.0` →
+  `"2.3.0"`). Ne pas inventer : reprendre exactement la valeur de `VERSION`.
+- `description`: 1 ligne décrivant VibeFlow (orchestrateur dev + modules, install plugin à toggles).
+- `author`: { "name": "picmakpro" }
+- `homepage` + `repository`: "https://github.com/picmakpro/vibeflow-os"
+- `license`: lire le fichier `LICENSE` pour confirmer l'identifiant (probable MIT) ; mettre
+  l'identifiant SPDX correspondant.
+- `keywords`: ["vibeflow", "gsd", "orchestrator", "modules", "install", "claude-code"]
+- `skills`: "./installer"  ← charge `installer/SKILL.md` comme skill `vibeflow-install`
+- `hooks`: "./installer/hooks/hooks.json"  ← câble le hook SessionStart
+
+IMPÉRATIF — ne PAS ajouter de dossier `skills/` à la racine ni y déplacer les modules : le champ
+`skills: "./installer"` suffit. Les modules restent des données bundlées (risque double-chargement
+spec §12).
+
+`.claude-plugin/marketplace.json` :
+- `name`: "vibeflow-os" (id du marketplace)
+- `owner`: { "name": "picmakpro" }
+- `plugins`: [ une seule entrée ] :
+  - `name`: "vibeflow"
+  - `description`: même description que plugin.json
+  - `version`: même version
+  - `source`: "./"  ← le repo EST le plugin (modèle Superpowers ; users ajoutent via GitHub donc
+    le chemin relatif résout)
+  - `category`: "development"
+  - `homepage`: "https://github.com/picmakpro/vibeflow-os"
+  - `author`: { "name": "picmakpro" }
+
+Écrire les fichiers avec l'outil Write (pas de heredoc).
+  </action>
+  <verify>
+    <automated>jq empty .claude-plugin/plugin.json && jq empty .claude-plugin/marketplace.json && jq -e '.name=="vibeflow" and .skills=="./installer" and (.hooks|test("installer/hooks/hooks.json")) and (.version|test("^[0-9]+\\.[0-9]+\\.[0-9]+"))' .claude-plugin/plugin.json && jq -e '.plugins[0].name=="vibeflow" and .plugins[0].source=="./" and .plugins[0].category=="development"' .claude-plugin/marketplace.json && claude plugin validate . 2>&1 | tail -5</automated>
+  </verify>
+  <done>Les deux JSON sont valides (jq empty), plugin.json déclare name=vibeflow + skills=./installer + hooks vers installer/hooks/hooks.json + version semver, marketplace.json liste le plugin vibeflow (source ./, category development), et `claude plugin validate .` ne renvoie pas d'erreur (warnings champs inconnus tolérés).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Câbler VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} dans le skill (PLUG-02)</name>
+  <files>installer/SKILL.md</files>
+  <action>
+Le skill délègue déjà à l'engine/catalogue/résolveur en mentionnant « VIBEFLOW_CACHE = cache du
+plugin » et « VF_MODULES_ROOT = cache du plugin » en prose vague. Rendre ce câblage EXPLICITE et
+non ambigu pour l'agent qui exécute le skill, conformément au &lt;plugin_model&gt; : en contexte
+plugin, le cache = `${CLAUDE_PLUGIN_ROOT}`, avec fallback repo en dev.
+
+Modifications dans `installer/SKILL.md` (ajouter une sous-section « Câblage du cache » au début de
+la section Garde-fous OU dans une note en tête de la section Séquence, sans réécrire le reste) :
+- Poser explicitement la convention de résolution du cache (à appliquer pour CHAQUE délégation —
+  étapes 1, 3, 4, 5) :
+  `VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-<racine du repo vibeflow-os en dev>}"` et de même
+  `VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-<racine du repo>}"`.
+- Préciser que `${CLAUDE_PLUGIN_ROOT}` est fourni par Claude Code à l'install du plugin et pointe
+  sur le cache (où vivent les modules + leurs `module.json` + `_internal/`), donc :
+  - étape 1 (status) : `VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-…}" vibeflow-update.sh status`
+  - étape 3 (catalogue) : `VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-…}" build-module-catalog.sh`
+  - étape 4 (résolveur) : `VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-…}" resolve-deps.sh …`
+  - étape 5 (install) : `VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-…}" vibeflow-update.sh --scope <s> install --with-deps <module>`
+- Fallback dev : quand `CLAUDE_PLUGIN_ROOT` est absent (travail dans le repo cloné, pas en plugin
+  installé), utiliser la racine du repo vibeflow-os comme cache — c'est le comportement déjà
+  supporté par les scripts (`VF_MODULES_ROOT` défaut = racine repo ; `VIBEFLOW_CACHE` défaut
+  `.vibeflow-cache`, donc en dev on le pointe explicitement sur la racine repo).
+- Mentionner que `_internal/resolve-deps.sh` est bundlé dans le plugin (présent dans le cache) →
+  `--with-deps` fonctionne après install (réponse au warning Phase 3).
+
+NE PAS modifier les scripts `.sh` (déjà scope-aware et cache-aware). NE PAS réimplémenter de logique :
+le skill reste un orchestrateur thin en prose. Ne pas toucher au frontmatter `name`/`description`.
+  </action>
+  <verify>
+    <automated>grep -q "CLAUDE_PLUGIN_ROOT" installer/SKILL.md && grep -c "CLAUDE_PLUGIN_ROOT" installer/SKILL.md | { read n; [ "$n" -ge 2 ]; } && grep -qi "fallback\|en dev\|repo" installer/SKILL.md && grep -q "resolve-deps" installer/SKILL.md</automated>
+  </verify>
+  <done>installer/SKILL.md pose explicitement `VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-…}"` et `VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-…}"` (au moins 2 occurrences de CLAUDE_PLUGIN_ROOT), documente le fallback repo en dev, et mentionne que resolve-deps.sh est bundlé. Les scripts .sh ne sont pas modifiés.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Réécrire la doc d'install (2 commandes + auto-lancement) — PLUG-02</name>
+  <files>README.md, INSTALL.md</files>
+  <action>
+Remplacer la procédure « clone manuel + cp script » par le flux plugin, conformément à la spec §1
+et §4.
+
+Dans `README.md` : ajouter/mettre à jour une section « Installation » en tête (ou remplacer celle
+existante) avec EXACTEMENT le flux 2-commandes :
+```
+claude plugin marketplace add picmakpro/vibeflow-os
+claude plugin install vibeflow
+```
+Puis expliquer l'auto-lancement (ID8) : à la session SUIVANTE (le chargement du plugin = restart),
+le hook SessionStart détecte le 1er lancement (marqueur `scripts/.vibeflow-installed` absent) et
+ouvre automatiquement l'UX `/vibeflow-install` (toggles scope + modules, dépendances auto-résolues).
+Aucun clone, aucun script à lancer, aucune édition de settings.json. Préciser que
+`/vibeflow-install` reste invocable à la main pour re-configurer/ajouter un module.
+
+Dans `INSTALL.md` : remplacer « Méthode 1 (clone .vibeflow-cache + cp) » et « Méthode 2 (clone
+manuel) » par la procédure plugin (mêmes 2 commandes + auto-lancement). Conserver les sections
+toujours valides (Mises à jour : remplacer par `claude plugin update vibeflow` ; Désinstallation ;
+Troubleshooting) en les adaptant au modèle plugin. SUPPRIMER les instructions de
+`git clone … .vibeflow-cache` et les références au repo « privé » dans les pré-requis (le repo
+devient public en Plan 02 ; ne pas exécuter ce flip ici, mais la doc d'install ne doit plus exiger
+d'accès privé/gh auth pour l'install plugin).
+
+Garder la langue française. Écrire avec l'outil Write/Edit.
+  </action>
+  <verify>
+    <automated>grep -q "claude plugin marketplace add picmakpro/vibeflow-os" README.md && grep -q "claude plugin install vibeflow" README.md && grep -qi "automatiquement\|auto-lanc\|SessionStart\|vibeflow-install" README.md && grep -q "claude plugin marketplace add picmakpro/vibeflow-os" INSTALL.md && ! grep -q "git clone --depth 1 https://github.com/picmakpro/vibeflow-os.git .vibeflow-cache" INSTALL.md</automated>
+  </verify>
+  <done>README.md et INSTALL.md décrivent le flux 2-commandes plugin + l'auto-lancement ; la procédure `git clone … .vibeflow-cache` est supprimée d'INSTALL.md ; les mises à jour passent par `claude plugin update vibeflow`.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| marketplace GitHub → cache local plugin | Code/manifeste téléchargé puis copié dans `~/.claude/plugins/cache` (Claude Code copie, ne lit pas en place) |
+| hook SessionStart → session de l'utilisateur | Le hook bundlé s'exécute non-sandboxé au démarrage (injecte un additionalContext) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-05-01 | Tampering | plugin.json/marketplace.json malformés | mitigate | `jq empty` + `claude plugin validate` en verify ; manifestes minimaux calqués sur Superpowers |
+| T-05-02 | Elevation | hook SessionStart non-sandboxé | accept | Hook déjà livré/testé Phase 4 (test-session-start.sh) ; lit seulement un marqueur, émet du JSON ; aucune écriture |
+| T-05-03 | Information disclosure | secrets dans le bundle public | mitigate | Checklist pré-public traitée en Plan 02 (audit secrets avant flip) ; ce plan ne rend pas le repo public |
+| T-05-04 | Spoofing | double-chargement skill plugin vs skills copiés | mitigate | Modules NON sous `skills/` ; plugin n'expose que `installer/` via champ `skills` (risque spec §12 neutralisé) |
+</threat_model>
+
+<verification>
+- `jq empty` passe sur les deux manifestes ; `claude plugin validate .` sans erreur.
+- plugin.json : name=vibeflow, version semver, skills=./installer, hooks→installer/hooks/hooks.json.
+- marketplace.json : entrée vibeflow, source "./", category development.
+- installer/SKILL.md : VIBEFLOW_CACHE + VF_MODULES_ROOT câblés sur ${CLAUDE_PLUGIN_ROOT} + fallback dev.
+- _internal/resolve-deps.sh présent dans le repo (bundle) → `ls _internal/resolve-deps.sh`.
+- README.md + INSTALL.md : 2 commandes plugin + auto-lancement, plus de clone manuel.
+- Aucun dossier `skills/` créé à la racine (pas de double-chargement).
+</verification>
+
+<success_criteria>
+- PLUG-01 : `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` valides, déclarant
+  skill + hook par la convention plugin.
+- PLUG-02 : bundle cohérent (modules + skill + engine + manifeste + résolveur présents), cache
+  câblé sur `${CLAUDE_PLUGIN_ROOT}` (fallback dev), doc d'install 2-commandes + auto-lancement.
+- Critère de succès Phase 5 #1 satisfait.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-packaging-plugin/05-01-SUMMARY.md`
+</output>

--- a/.planning/phases/05-packaging-plugin/05-01-SUMMARY.md
+++ b/.planning/phases/05-packaging-plugin/05-01-SUMMARY.md
@@ -1,0 +1,105 @@
+---
+phase: 05-packaging-plugin
+plan: 01
+subsystem: packaging
+tags: [plugin, marketplace, hooks, install-ux, claude-code]
+requires:
+  - "installer/SKILL.md (skill vibeflow-install)"
+  - "installer/hooks/session-start (hook 1er lancement, livré Phase 4)"
+  - "_internal/vibeflow-update.sh + resolve-deps.sh + build-module-catalog.sh (engine)"
+provides:
+  - ".claude-plugin/plugin.json (manifeste plugin)"
+  - ".claude-plugin/marketplace.json (entrée marketplace)"
+  - "Doc d'install plugin 2-commandes + auto-lancement"
+affects:
+  - "README.md, INSTALL.md (section installation)"
+tech-stack:
+  added: []
+  patterns:
+    - "Plugin Claude Code : skills via champ skills, hooks via champ hooks (pas de skills/ racine)"
+    - "Cache câblé sur ${CLAUDE_PLUGIN_ROOT} avec fallback dev repo"
+key-files:
+  created:
+    - ".claude-plugin/plugin.json"
+    - ".claude-plugin/marketplace.json"
+  modified:
+    - "installer/SKILL.md"
+    - "README.md"
+    - "INSTALL.md"
+decisions:
+  - "license = UNLICENSED (LICENSE proprietaire all-rights-reserved, PAS MIT comme supposé au plan)"
+  - "Ajout d'une description racine au marketplace.json pour lever le warning claude plugin validate"
+metrics:
+  duration_min: 2
+  completed: "2026-06-04"
+  tasks: 3
+  files: 5
+---
+
+# Phase 5 Plan 01 : Packaging plugin VibeFlow Summary
+
+Transformation de `vibeflow-os` en plugin Claude Code installable via marketplace : deux manifestes valides calqués sur Superpowers, cache du skill câblé sur `${CLAUDE_PLUGIN_ROOT}` (fallback dev), hook SessionStart vérifié résolvable au runtime, et doc d'install réécrite en flux 2-commandes + auto-lancement.
+
+## Tasks réalisées
+
+| Task | Nom | Commit | Fichiers |
+|------|-----|--------|----------|
+| 1 | Manifestes plugin + vérif hook (PLUG-01) | `26e55b8` | .claude-plugin/plugin.json, .claude-plugin/marketplace.json |
+| 2 | Câblage VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT} (PLUG-02) | `9b8b199` | installer/SKILL.md |
+| 3 | Doc install plugin 2-commandes + auto-lancement (PLUG-02) | `b8da662` | README.md, INSTALL.md |
+
+## Vérification
+
+- `jq empty` : plugin.json + marketplace.json + hooks.json → tous JSON valides.
+- `claude plugin validate .` → **Validation passed** (sans warning après ajout description marketplace).
+- plugin.json : `name=vibeflow`, `version=2.3.0`, `skills=./installer`, `hooks=./installer/hooks/hooks.json`.
+- marketplace.json : entrée `vibeflow`, `source=./`, `category=development`.
+- **SMOKE TEST runtime du hook** : `${CLAUDE_PLUGIN_ROOT}` résolu sur la racine repo → `installer/hooks/session-start` existe + exécutable ; exécuté en HOME/CWD temporaire (mktemp), émet un JSON dont `additionalContext` contient `vibeflow-install`. Le vrai `~/.claude` n'est pas touché.
+- installer/SKILL.md : frontmatter `name: vibeflow-install` présent ; 10 occurrences hors-commentaire de `CLAUDE_PLUGIN_ROOT` ; fallback dev + mention `resolve-deps` présents. Scripts `.sh` non modifiés.
+- `_internal/resolve-deps.sh` présent dans le bundle (--with-deps fonctionne après install).
+- Aucun dossier `skills/` à la racine → pas de double-chargement (T-05-04 neutralisé).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] license = UNLICENSED, pas MIT**
+- **Found during:** Task 1
+- **Issue:** Le plan supposait une licence MIT « probable ». Le fichier `LICENSE` est en réalité proprietaire (« Copyright (c) 2026 picmakpro / All rights reserved »).
+- **Fix:** Utilisé l'identifiant `"UNLICENSED"` (convention proprietaire), conforme à la source de vérité LICENSE plutôt qu'à l'hypothèse du plan.
+- **Files modified:** .claude-plugin/plugin.json
+- **Commit:** `26e55b8`
+
+**2. [Rule 2 - Missing] description racine du marketplace.json**
+- **Found during:** Task 1 (verify `claude plugin validate`)
+- **Issue:** `claude plugin validate` émettait un warning « No marketplace description provided ».
+- **Fix:** Ajouté un champ `description` à la racine de marketplace.json → validation 100% propre.
+- **Files modified:** .claude-plugin/marketplace.json
+- **Commit:** `26e55b8`
+
+### Écarts informatifs (pas de correction nécessaire)
+
+- **hooks.json déjà corrigé** : la Task 1 (A) prévoyait de corriger le chemin du hook si nécessaire. Le fichier `installer/hooks/hooks.json` pointait déjà sur `installer/hooks/session-start` (corrigé par le commit pre-plan `33c2d27`). Aucune modification requise — le smoke test runtime confirme la résolution. hooks.json n'est donc pas dans les commits de ce plan.
+
+## Auth gates
+
+Aucun.
+
+## Known Stubs
+
+Aucun stub introduit.
+
+## Threat Flags
+
+Aucune nouvelle surface de menace hors threat_model du plan.
+
+## Self-Check: PASSED
+
+- FOUND: .claude-plugin/plugin.json
+- FOUND: .claude-plugin/marketplace.json
+- FOUND: installer/SKILL.md (modifié)
+- FOUND: README.md (modifié)
+- FOUND: INSTALL.md (modifié)
+- FOUND commit: 26e55b8
+- FOUND commit: 9b8b199
+- FOUND commit: b8da662

--- a/.planning/phases/05-packaging-plugin/05-02-PLAN.md
+++ b/.planning/phases/05-packaging-plugin/05-02-PLAN.md
@@ -14,10 +14,11 @@ must_haves:
     - "Une checklist pré-public existe (audit secrets, LICENSE OK, manifestes valides) et est vérifiée AVANT tout flip de visibilité"
     - "La procédure de mise en public est documentée comme étape MANUELLE confirmée hors-agent (jamais lancée par un executor autonome)"
     - "La séquence de validation post-public (marketplace add + install zéro-auth) est documentée avec les commandes exactes à lancer"
+    - "Une procédure de dépannage zéro-auth est documentée : si marketplace add demande encore une auth sur un repo fraîchement public (cache GitHub / lag de ré-indexation), remove + re-add + vérifier la propagation de visibilité — pour que PLUG-04 ne soit pas une impasse"
     - "Aucune commande `gh repo edit --visibility public` n'est exécutée automatiquement par ce plan"
   artifacts:
     - path: "docs/superpowers/specs/SHIPPING-CHECKLIST.md"
-      provides: "Checklist pré-public + commandes flip + séquence de validation post-public"
+      provides: "Checklist pré-public + commandes flip + séquence de validation post-public + dépannage zéro-auth"
       contains: "gh repo edit"
   key_links:
     - from: "docs/superpowers/specs/SHIPPING-CHECKLIST.md"
@@ -70,6 +71,14 @@ Validation zéro-auth post-public (lancée par l'utilisateur après le flip) :
   claude plugin install vibeflow
   # puis : nouvelle session → le hook SessionStart ouvre /vibeflow-install automatiquement
 
+Dépannage zéro-auth (si marketplace add demande ENCORE une auth sur un repo fraîchement public —
+cache GitHub côté Claude Code ou lag de ré-indexation marketplace) :
+  claude plugin marketplace remove vibeflow-os   # purge l'entrée en cache
+  claude plugin marketplace add picmakpro/vibeflow-os   # re-add → re-fetch propre
+  # vérifier que la visibilité publique est bien propagée côté GitHub :
+  gh repo view picmakpro/vibeflow-os --json visibility
+  # attendre quelques minutes la ré-indexation si la visibilité est correcte mais l'auth persiste.
+
 Audit secrets (lecture seule) :
   git log --all -p | grep -nEi 'AKIA|secret|api[_-]?key|token|password|-----BEGIN' (revue manuelle)
   ls -a à la racine pour repérer .env, *.p8, *.p12, *.cer, credentials.
@@ -119,6 +128,17 @@ Sections du document :
      à la session suivante, le hook SessionStart ouvre `/vibeflow-install` automatiquement.
    - Critères de validation (à cocher après exécution réelle) : marketplace ajouté, plugin
      installé, skill `/vibeflow-install` listé, hook actif.
+   - **Dépannage zéro-auth (IMPORTANT — pour que PLUG-04 ne soit pas une impasse)** : si
+     `marketplace add` sur le repo fraîchement public demande ENCORE une authentification GitHub
+     (cause probable : cache GitHub côté Claude Code OU lag de ré-indexation du marketplace après
+     le flip), procédure de récupération :
+     1. `claude plugin marketplace remove vibeflow-os` (purge l'entrée mise en cache).
+     2. `claude plugin marketplace add picmakpro/vibeflow-os` (re-add → re-fetch propre).
+     3. Vérifier que la visibilité publique est bien propagée :
+        `gh repo view picmakpro/vibeflow-os --json visibility` doit renvoyer `"PUBLIC"`.
+     4. Si la visibilité est correcte mais l'auth persiste, attendre quelques minutes (ré-indexation
+        marketplace côté GitHub) puis re-tenter le remove + add.
+     Ne PAS considérer PLUG-04 comme échoué tant que cette procédure n'a pas été déroulée.
 
 En tête du document, un bloc clair : « ⚠️ Ce document est une PROCÉDURE CONFIRMÉE HORS-AGENT pour
 les étapes §2 et §3. Aucun agent autonome ne doit exécuter le flip public ni l'install. »
@@ -126,9 +146,9 @@ les étapes §2 et §3. Aucun agent autonome ne doit exécuter le flip public ni
 Écrire avec l'outil Write.
   </action>
   <verify>
-    <automated>test -f docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -q "gh repo edit picmakpro/vibeflow-os --visibility public" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -q "claude plugin marketplace add picmakpro/vibeflow-os" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -qi "hors-agent\|confirmé\|irréversible" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -qi "secret\|LICENSE" docs/superpowers/specs/SHIPPING-CHECKLIST.md</automated>
+    <automated>test -f docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -q "gh repo edit picmakpro/vibeflow-os --visibility public" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -q "claude plugin marketplace add picmakpro/vibeflow-os" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -q "claude plugin marketplace remove vibeflow-os" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -qi "hors-agent\|confirmé\|irréversible" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -qi "secret\|LICENSE" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -qi "ré-indexation\|reindex\|cache GitHub\|auth" docs/superpowers/specs/SHIPPING-CHECKLIST.md</automated>
   </verify>
-  <done>SHIPPING-CHECKLIST.md existe, contient la checklist pré-public (secrets + LICENSE + manifestes), la commande `gh repo edit … --visibility public` marquée hors-agent/irréversible, et la séquence de validation `marketplace add` + `install`. Les items de checklist exécutables en lecture seule sont pré-remplis avec l'état constaté.</done>
+  <done>SHIPPING-CHECKLIST.md existe, contient la checklist pré-public (secrets + LICENSE + manifestes), la commande `gh repo edit … --visibility public` marquée hors-agent/irréversible, la séquence de validation `marketplace add` + `install`, ET la procédure de dépannage zéro-auth (remove + re-add + vérif visibilité `gh repo view --json visibility`, attente ré-indexation). Les items de checklist exécutables en lecture seule sont pré-remplis avec l'état constaté.</done>
 </task>
 
 <task type="checkpoint:human-action" gate="blocking">
@@ -157,7 +177,8 @@ Aucune visibilité de repo n'a été modifiée par l'agent.
   <name>Task 3 (CHECKPOINT — hors-agent): Valider marketplace add + install zéro-auth (PLUG-04)</name>
   <action>NE PAS EXÉCUTER côté agent. L'executor s'ARRÊTE ici et présente le checkpoint. La validation (marketplace add + install) est lancée MANUELLEMENT par l'utilisateur APRÈS le flip public.</action>
   <what-built>
-La procédure de validation zéro-auth est documentée dans SHIPPING-CHECKLIST.md §3 (PLUG-04).
+La procédure de validation zéro-auth est documentée dans SHIPPING-CHECKLIST.md §3 (PLUG-04),
+y compris le dépannage si l'auth persiste sur un repo fraîchement public.
   </what-built>
   <how-to-verify>
 VALIDATION POST-PUBLIC — à lancer une fois le repo public (depuis une machine SANS auth GitHub
@@ -170,8 +191,16 @@ configurée pour le repo, idéalement) :
 4. Ouvrir une nouvelle session Claude Code → l'UX `/vibeflow-install` doit s'ouvrir
    automatiquement (1er lancement, marqueur absent).
 5. Cocher les critères de validation §3 dans SHIPPING-CHECKLIST.md.
+
+⚠️ SI `marketplace add` demande ENCORE une auth (repo pourtant rendu public) — cache GitHub ou
+lag de ré-indexation marketplace — NE PAS conclure à un échec : dérouler le dépannage zéro-auth
+de SHIPPING-CHECKLIST.md §3 :
+   a. `claude plugin marketplace remove vibeflow-os`
+   b. `claude plugin marketplace add picmakpro/vibeflow-os` (re-fetch propre)
+   c. `gh repo view picmakpro/vibeflow-os --json visibility` doit renvoyer `"PUBLIC"`
+   d. si visibilité OK mais auth persiste, attendre quelques minutes (ré-indexation) puis re-tenter.
   </how-to-verify>
-  <resume-signal>Tapez "validé zéro-auth" si add+install fonctionnent sans auth, ou décrivez l'échec.</resume-signal>
+  <resume-signal>Tapez "validé zéro-auth" si add+install fonctionnent sans auth (au besoin après le dépannage remove/re-add), ou décrivez l'échec.</resume-signal>
 </task>
 
 </tasks>
@@ -191,22 +220,26 @@ configurée pour le repo, idéalement) :
 | T-05-05 | Information disclosure | secrets/historique exposés au flip public | mitigate | Checklist §1 audit secrets + historique AVANT le flip ; flip bloqué tant que checklist non cochée |
 | T-05-06 | Elevation | exécution autonome d'une action irréversible | mitigate | Plan NON-autonome (autonomous:false) ; flip = checkpoint:human-action ; aucune commande de visibilité dans une task `auto` |
 | T-05-07 | Repudiation | flip lancé sans confirmation traçable | accept | Confirmation explicite via resume-signal du checkpoint ; trace dans STATE/SUMMARY |
+| T-05-09 | Denial of service | marketplace add bloqué par auth résiduelle (cache/lag) → PLUG-04 perçu comme impasse | mitigate | Procédure de dépannage zéro-auth documentée (remove + re-add + vérif visibilité + attente ré-indexation) en §3 et dans le checkpoint Task 3 |
 </threat_model>
 
 <verification>
-- SHIPPING-CHECKLIST.md existe avec checklist pré-public + commandes flip + validation.
+- SHIPPING-CHECKLIST.md existe avec checklist pré-public + commandes flip + validation + dépannage zéro-auth.
 - Le plan est `autonomous: false` ; le flip et la validation sont des checkpoints bloquants.
 - AUCUNE task `type: auto` ne contient `gh repo edit --visibility public` exécutée automatiquement
   (la commande n'apparaît que dans la DOC et le checkpoint, comme instruction à l'utilisateur).
+- La procédure de dépannage (remove + re-add + `gh repo view --json visibility`) est documentée.
 </verification>
 
 <success_criteria>
 - PLUG-03 : procédure de mise en public documentée + flip exécuté MANUELLEMENT par l'utilisateur
   sur confirmation (checkpoint), jamais par l'agent.
-- PLUG-04 : `marketplace add` + `install` validés en zéro-auth après le flip (checkpoint).
+- PLUG-04 : `marketplace add` + `install` validés en zéro-auth après le flip (checkpoint), avec
+  un chemin de récupération documenté si l'auth persiste (remove/re-add/ré-indexation).
 - Critère de succès Phase 5 #2 satisfait.
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/05-packaging-plugin/05-02-SUMMARY.md`
+</output>
 </output>

--- a/.planning/phases/05-packaging-plugin/05-02-PLAN.md
+++ b/.planning/phases/05-packaging-plugin/05-02-PLAN.md
@@ -1,0 +1,212 @@
+---
+phase: 05-packaging-plugin
+plan: 02
+type: execute
+wave: 2
+depends_on: ["05-01"]
+files_modified:
+  - docs/superpowers/specs/SHIPPING-CHECKLIST.md
+autonomous: false
+requirements: [PLUG-03, PLUG-04]
+
+must_haves:
+  truths:
+    - "Une checklist pré-public existe (audit secrets, LICENSE OK, manifestes valides) et est vérifiée AVANT tout flip de visibilité"
+    - "La procédure de mise en public est documentée comme étape MANUELLE confirmée hors-agent (jamais lancée par un executor autonome)"
+    - "La séquence de validation post-public (marketplace add + install zéro-auth) est documentée avec les commandes exactes à lancer"
+    - "Aucune commande `gh repo edit --visibility public` n'est exécutée automatiquement par ce plan"
+  artifacts:
+    - path: "docs/superpowers/specs/SHIPPING-CHECKLIST.md"
+      provides: "Checklist pré-public + commandes flip + séquence de validation post-public"
+      contains: "gh repo edit"
+  key_links:
+    - from: "docs/superpowers/specs/SHIPPING-CHECKLIST.md"
+      to: ".claude-plugin/marketplace.json"
+      via: "validation marketplace add picmakpro/vibeflow-os"
+      pattern: "marketplace add"
+---
+
+<objective>
+Préparer le SHIPPING de VibeFlow en plugin public : produire une checklist pré-public auditable
+(pas de secrets, LICENSE OK, manifestes valides) et la documenter, puis MARQUER les deux actions
+outward-facing (PLUG-03 rendre le repo public, PLUG-04 valider `marketplace add` + `install` en
+zéro-auth) comme CONFIRMÉES HORS-AGENT.
+
+⚠️ PLAN CONFIRMATION-GATED / NON-AUTONOME ⚠️
+Ce plan NE rend PAS le repo public et NE lance AUCUNE commande qui change la visibilité du repo
+(`gh repo edit --visibility public`) ni d'install plugin réelle. L'executor PRÉPARE la checklist
+et les commandes ; l'EXÉCUTION RÉELLE du flip public et de la validation est une action délibérée,
+quasi-irréversible, confirmée par l'orchestrateur + l'utilisateur, réalisée hors de tout agent
+autonome (spec §12, décision ID2).
+
+Purpose: PLUG-03 (flip public — documenté/gated) + PLUG-04 (validation zéro-auth — documentée/gated).
+Couvre le critère de succès Phase 5 #2 : « marketplace add + install fonctionnent en zéro-auth ».
+
+Output: `docs/superpowers/specs/SHIPPING-CHECKLIST.md` + deux checkpoints de confirmation.
+
+Langue : français.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+# Produits par le Plan 05-01 (manifestes) — à vérifier dans la checklist
+@.claude-plugin/plugin.json
+@.claude-plugin/marketplace.json
+
+<interfaces>
+<!-- Commandes de shipping (à DOCUMENTER, pas à exécuter automatiquement). -->
+Flip visibilité (MANUEL, confirmé hors-agent — JAMAIS lancé par un executor) :
+  gh repo edit picmakpro/vibeflow-os --visibility public --accept-visibility-change-consequences
+
+Validation zéro-auth post-public (lancée par l'utilisateur après le flip) :
+  claude plugin marketplace add picmakpro/vibeflow-os
+  claude plugin install vibeflow
+  # puis : nouvelle session → le hook SessionStart ouvre /vibeflow-install automatiquement
+
+Audit secrets (lecture seule) :
+  git log --all -p | grep -nEi 'AKIA|secret|api[_-]?key|token|password|-----BEGIN' (revue manuelle)
+  ls -a à la racine pour repérer .env, *.p8, *.p12, *.cer, credentials.
+LICENSE : fichier `LICENSE` présent à la racine.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Rédiger la checklist de shipping pré-public + procédures gated</name>
+  <files>docs/superpowers/specs/SHIPPING-CHECKLIST.md</files>
+  <action>
+Créer `docs/superpowers/specs/SHIPPING-CHECKLIST.md` (français). Ce document est de la DOC : il
+décrit la checklist et les commandes, mais l'executor NE LANCE PAS le flip public ni l'install.
+
+L'executor PEUT exécuter les vérifications de checklist en LECTURE SEULE pour pré-cocher les items
+(audit secrets, présence LICENSE, validité manifestes) — aucune de ces commandes ne change l'état
+du repo. Pré-remplir l'état de chaque item dans le doc à partir des résultats.
+
+Sections du document :
+
+1. **Checklist pré-public (à valider AVANT le flip)** — cases à cocher avec état constaté :
+   - [ ] Aucun secret dans l'historique ni l'arbre de travail : auditer
+     `git log --all --oneline | wc -l` puis grep secrets (AKIA, api_key, token, password,
+     `-----BEGIN`) ; vérifier l'absence de `.env`, `*.p8`, `*.p12`, `*.cer`, credentials à la
+     racine et dans les modules. Reporter le résultat (clean / items à traiter).
+   - [ ] `LICENSE` présent à la racine et identifiant cohérent avec `plugin.json`.
+   - [ ] `.claude-plugin/plugin.json` et `.claude-plugin/marketplace.json` valides
+     (`jq empty` + `claude plugin validate .`) — réutiliser le verify du Plan 01.
+   - [ ] `.gitignore` couvre bien les caches/artefacts (`.vibeflow-cache/`, backups, logs) → rien
+     de sensible committé.
+   - [ ] README/INSTALL à jour (flux 2-commandes, plus de clone manuel) — Plan 01.
+
+2. **Étape MANUELLE confirmée hors-agent — flip public (PLUG-03)** :
+   - Encadré d'AVERTISSEMENT : action quasi-irréversible (contenu rendu visible), délibérée,
+     confirmée explicitement par l'utilisateur, JAMAIS lancée par un agent autonome.
+   - Commande EXACTE à lancer par l'utilisateur (ou l'orchestrateur sur confirmation explicite) :
+     `gh repo edit picmakpro/vibeflow-os --visibility public --accept-visibility-change-consequences`
+   - Pré-condition : toute la checklist §1 cochée.
+
+3. **Validation post-public — zéro-auth (PLUG-04)** :
+   - Commandes EXACTES à lancer APRÈS le flip :
+     `claude plugin marketplace add picmakpro/vibeflow-os`
+     `claude plugin install vibeflow`
+   - Résultat attendu : ajout + install réussissent SANS authentification GitHub (repo public) ;
+     à la session suivante, le hook SessionStart ouvre `/vibeflow-install` automatiquement.
+   - Critères de validation (à cocher après exécution réelle) : marketplace ajouté, plugin
+     installé, skill `/vibeflow-install` listé, hook actif.
+
+En tête du document, un bloc clair : « ⚠️ Ce document est une PROCÉDURE CONFIRMÉE HORS-AGENT pour
+les étapes §2 et §3. Aucun agent autonome ne doit exécuter le flip public ni l'install. »
+
+Écrire avec l'outil Write.
+  </action>
+  <verify>
+    <automated>test -f docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -q "gh repo edit picmakpro/vibeflow-os --visibility public" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -q "claude plugin marketplace add picmakpro/vibeflow-os" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -qi "hors-agent\|confirmé\|irréversible" docs/superpowers/specs/SHIPPING-CHECKLIST.md && grep -qi "secret\|LICENSE" docs/superpowers/specs/SHIPPING-CHECKLIST.md</automated>
+  </verify>
+  <done>SHIPPING-CHECKLIST.md existe, contient la checklist pré-public (secrets + LICENSE + manifestes), la commande `gh repo edit … --visibility public` marquée hors-agent/irréversible, et la séquence de validation `marketplace add` + `install`. Les items de checklist exécutables en lecture seule sont pré-remplis avec l'état constaté.</done>
+</task>
+
+<task type="checkpoint:human-action" gate="blocking">
+  <name>Task 2 (CHECKPOINT — hors-agent): Flip repo public (PLUG-03)</name>
+  <action>NE PAS EXÉCUTER côté agent. L'executor s'ARRÊTE ici et présente le checkpoint. Le flip de visibilité est exécuté MANUELLEMENT par l'utilisateur après confirmation. Aucune commande `gh repo edit --visibility public` n'est lancée par l'agent.</action>
+  <what-built>
+La checklist pré-public est rédigée et les items en lecture seule (audit secrets, LICENSE,
+validité des manifestes) sont pré-cochés dans `docs/superpowers/specs/SHIPPING-CHECKLIST.md`.
+Aucune visibilité de repo n'a été modifiée par l'agent.
+  </what-built>
+  <how-to-verify>
+ÉTAPE OUTWARD-FACING, QUASI-IRRÉVERSIBLE, À CONFIRMER (PLUG-03) :
+
+1. Relire `docs/superpowers/specs/SHIPPING-CHECKLIST.md` §1 et confirmer que TOUS les items
+   pré-public sont OK (aucun secret, LICENSE OK, manifestes valides, .gitignore propre, doc à jour).
+2. Si tout est OK et que vous décidez délibérément de rendre le repo public, lancer VOUS-MÊME :
+   `gh repo edit picmakpro/vibeflow-os --visibility public --accept-visibility-change-consequences`
+3. Vérifier sur GitHub que le repo `picmakpro/vibeflow-os` est bien public.
+
+⚠️ L'agent NE lance PAS cette commande. C'est une action délibérée que vous exécutez à la main.
+  </how-to-verify>
+  <resume-signal>Tapez "public confirmé" une fois le repo rendu public, ou "pas encore" pour différer le shipping.</resume-signal>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3 (CHECKPOINT — hors-agent): Valider marketplace add + install zéro-auth (PLUG-04)</name>
+  <action>NE PAS EXÉCUTER côté agent. L'executor s'ARRÊTE ici et présente le checkpoint. La validation (marketplace add + install) est lancée MANUELLEMENT par l'utilisateur APRÈS le flip public.</action>
+  <what-built>
+La procédure de validation zéro-auth est documentée dans SHIPPING-CHECKLIST.md §3 (PLUG-04).
+  </what-built>
+  <how-to-verify>
+VALIDATION POST-PUBLIC — à lancer une fois le repo public (depuis une machine SANS auth GitHub
+configurée pour le repo, idéalement) :
+
+1. `claude plugin marketplace add picmakpro/vibeflow-os` → doit réussir sans demander d'auth.
+2. `claude plugin install vibeflow` → doit installer le plugin.
+3. Vérifier : `claude plugin details vibeflow` liste le skill `vibeflow-install` et le hook
+   SessionStart.
+4. Ouvrir une nouvelle session Claude Code → l'UX `/vibeflow-install` doit s'ouvrir
+   automatiquement (1er lancement, marqueur absent).
+5. Cocher les critères de validation §3 dans SHIPPING-CHECKLIST.md.
+  </how-to-verify>
+  <resume-signal>Tapez "validé zéro-auth" si add+install fonctionnent sans auth, ou décrivez l'échec.</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| repo privé → public | Flip de visibilité : tout le contenu + l'historique deviennent publics (irréversible de facto) |
+| marketplace public → installeurs anonymes | N'importe qui peut `marketplace add` + `install` une fois public |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-05-05 | Information disclosure | secrets/historique exposés au flip public | mitigate | Checklist §1 audit secrets + historique AVANT le flip ; flip bloqué tant que checklist non cochée |
+| T-05-06 | Elevation | exécution autonome d'une action irréversible | mitigate | Plan NON-autonome (autonomous:false) ; flip = checkpoint:human-action ; aucune commande de visibilité dans une task `auto` |
+| T-05-07 | Repudiation | flip lancé sans confirmation traçable | accept | Confirmation explicite via resume-signal du checkpoint ; trace dans STATE/SUMMARY |
+</threat_model>
+
+<verification>
+- SHIPPING-CHECKLIST.md existe avec checklist pré-public + commandes flip + validation.
+- Le plan est `autonomous: false` ; le flip et la validation sont des checkpoints bloquants.
+- AUCUNE task `type: auto` ne contient `gh repo edit --visibility public` exécutée automatiquement
+  (la commande n'apparaît que dans la DOC et le checkpoint, comme instruction à l'utilisateur).
+</verification>
+
+<success_criteria>
+- PLUG-03 : procédure de mise en public documentée + flip exécuté MANUELLEMENT par l'utilisateur
+  sur confirmation (checkpoint), jamais par l'agent.
+- PLUG-04 : `marketplace add` + `install` validés en zéro-auth après le flip (checkpoint).
+- Critère de succès Phase 5 #2 satisfait.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-packaging-plugin/05-02-SUMMARY.md`
+</output>

--- a/.planning/phases/05-packaging-plugin/05-02-SUMMARY.md
+++ b/.planning/phases/05-packaging-plugin/05-02-SUMMARY.md
@@ -1,0 +1,82 @@
+---
+phase: 05-packaging-plugin
+plan: 02
+subsystem: infra
+tags: [shipping, plugin, marketplace, github-visibility, security-audit, gated]
+
+requires:
+  - phase: 05-packaging-plugin (05-01)
+    provides: ".claude-plugin/plugin.json, .claude-plugin/marketplace.json, INSTALL.md (flux 2-commandes)"
+provides:
+  - "docs/superpowers/specs/SHIPPING-CHECKLIST.md — checklist pré-public auditée + procédures flip/validation gated"
+  - "Pré-audit lecture seule : scan secrets clean, LICENSE OK, manifestes valides, .gitignore propre"
+affects: [PLUG-03, PLUG-04, shipping public, marketplace zéro-auth]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Plan confirmation-gated : actions outward-facing (flip public, install) documentées mais jamais exécutées par un agent autonome"
+
+key-files:
+  created:
+    - docs/superpowers/specs/SHIPPING-CHECKLIST.md
+  modified: []
+
+key-decisions:
+  - "Flip public et validation marketplace = checkpoints humains hors-agent (T-05-06) — Task 1 seule exécutée par l'executor"
+  - "LICENSE All rights reserved + plugin.json UNLICENSED → repo public = source-available (code visible, aucun droit de réutilisation accordé)"
+  - "README mentionne encore 'Privé' (lignes 4, 105) → à mettre à jour avant/au flip"
+
+patterns-established:
+  - "Audit secrets en lecture seule pré-rempli dans la checklist (0 credential réel sur 50 commits)"
+  - "Procédure de dépannage zéro-auth (remove + re-add + vérif visibilité + attente ré-indexation) pour éviter une impasse PLUG-04"
+
+requirements-completed: []  # PLUG-03 / PLUG-04 restent EN ATTENTE des checkpoints humains (Tasks 2-3)
+
+duration: ~6min
+completed: 2026-06-04
+---
+
+# Phase 5 Plan 02: Shipping Checklist & Procédures Gated Summary
+
+**Checklist de shipping pré-public auditée (secrets clean, LICENSE OK, manifestes valides) + procédures flip-public et validation marketplace zéro-auth documentées comme étapes humaines hors-agent — Tasks 2-3 en attente de confirmation utilisateur.**
+
+## Performance
+
+- **Duration:** ~6 min
+- **Tasks:** 1/3 exécutée (Tasks 2-3 = checkpoints humains, NON exécutées par design)
+- **Files modified:** 1 créé
+
+## Accomplishments
+
+- Créé `docs/superpowers/specs/SHIPPING-CHECKLIST.md` (français) :
+  - §1 checklist pré-public avec état constaté pré-rempli (lecture seule)
+  - §2 flip public (PLUG-03) marqué quasi-irréversible / hors-agent — commande documentée, **non exécutée**
+  - §3 validation zéro-auth (PLUG-04) : `marketplace add` + `install` + procédure de dépannage (cache/ré-indexation)
+- Audit pré-public en lecture seule (aucune mutation du repo) :
+  - **Scan secrets : CLEAN.** 50 commits audités. 0 correspondance haute-confiance (AWS keys, blocs PRIVATE KEY, tokens gh*/sk-/xox*, assignations `key=valeur`). Les ~267 matches du grep large sont exclusivement de la prose de planification (specs/plans/threat models + la commande d'audit elle-même), pas des credentials. Aucun `.env`/`*.p8`/`*.p12`/`*.cer`/credentials.
+  - **LICENSE :** présent, `All rights reserved` (picmakpro). Cohérent avec `plugin.json` `license: UNLICENSED`. Conséquence documentée : repo public = **source-available** (code visible, aucun droit de réutilisation).
+  - **Manifestes :** `plugin.json` et `marketplace.json` = JSON valides (`jq empty`), versions alignées 2.3.0.
+  - **`.gitignore` :** couvre `.vibeflow-cache/`, backups, logs, caches Python/éditeur — propre.
+  - **README :** mentionne encore « Privé » (lignes 4 et 105) → flag à mettre à jour avant/au flip.
+
+## Statut des étapes outward-facing (EN ATTENTE)
+
+- ⏸️ **Task 2 — PLUG-03 (flip public)** : `checkpoint:human-action`. **NON exécutée.** Aucune commande `gh repo edit --visibility public` lancée. Repo confirmé **PRIVATE** au moment de l'exécution. À lancer manuellement par l'utilisateur après validation de la checklist §1.
+- ⏸️ **Task 3 — PLUG-04 (validation zéro-auth)** : `checkpoint:human-verify`. **NON exécutée.** `marketplace add` / `install` à lancer par l'utilisateur APRÈS le flip public.
+
+Ces deux étapes sont gérées hors-agent par l'orchestrateur + l'utilisateur (spec §12, décision ID2). Cet executor était scopé à la Task 1 uniquement.
+
+## Deviations from Plan
+
+None - Task 1 exécutée exactement comme écrite. Aucune fonctionnalité critique manquante détectée.
+
+## Verification
+
+- Verify automated du plan : **PASS** (fichier présent ; contient la commande flip, `marketplace add`, `marketplace remove`, mentions hors-agent/irréversible, secret/LICENSE, ré-indexation/auth).
+- Confirmé : **aucune** action outward-facing exécutée (pas de flip de visibilité, pas d'install). Repo resté PRIVATE.
+
+## Self-Check: PASSED
+
+- `docs/superpowers/specs/SHIPPING-CHECKLIST.md` : FOUND
+- Commit `644f622` : FOUND

--- a/.planning/phases/06-dev-orchestrator-first-use/06-01-PLAN.md
+++ b/.planning/phases/06-dev-orchestrator-first-use/06-01-PLAN.md
@@ -1,0 +1,244 @@
+---
+phase: 06-dev-orchestrator-first-use
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - dev-orchestrator/AGENT.md
+  - dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
+autonomous: true
+requirements: [FIRST-01, FIRST-02]
+must_haves:
+  truths:
+    - "AGENT.md décrit un garde-fou de premier usage : avant de router une intention de dev (code/planifie/teste…) sur un projet sans `.planning/`, l'agent détecte l'absence et bascule sur la proposition d'init"
+    - "AGENT.md nomme la détection par absence de `.planning/PROJECT.md` (ou `.planning/`) comme déclencheur (FIRST-01)"
+    - "AGENT.md précise que dans ce cas l'agent PROPOSE cartographie (map-codebase, si du code existe) puis démarrage de projet (new-project) sur confirmation explicite, et ne lance JAMAIS new-project seul (FIRST-02, cohérent BOOT-04)"
+    - "AGENT.md délègue la séquence d'init au skill vf-init existant (pas de duplication de la séquence)"
+    - "AGENT.md reste ≤250 lignes (charte densité, T5)"
+    - "Le test du module gagne un axe (T7) qui échoue si le garde-fou first-use (détection `.planning` + délégation vf-init) disparaît d'AGENT.md"
+  artifacts:
+    - path: "dev-orchestrator/AGENT.md"
+      provides: "Garde-fou first-use : détection `.planning/` absent + proposition d'init déléguée à vf-init, avant routage d'une intention de dev"
+      contains: ".planning"
+    - path: "dev-orchestrator/scripts/tests/test-dev-orchestrator.sh"
+      provides: "Axe T7 vérifiant la présence du garde-fou first-use dans AGENT.md (détection `.planning` + référence vf-init + interdiction de new-project seul)"
+      contains: "first-use"
+  key_links:
+    - from: "dev-orchestrator/AGENT.md (garde-fou first-use)"
+      to: "skill vf-init"
+      via: "délégation explicite de la séquence d'init (proposition map-codebase puis new-project sur confirmation)"
+      pattern: "vf-init"
+    - from: "dev-orchestrator/AGENT.md (garde-fou first-use)"
+      to: "détection projet non GSD-initialisé"
+      via: "absence de .planning/PROJECT.md (ou .planning/)"
+      pattern: "\\.planning"
+    - from: "dev-orchestrator/scripts/tests/test-dev-orchestrator.sh (T7)"
+      to: "dev-orchestrator/AGENT.md"
+      via: "grep du garde-fou first-use (détection .planning + vf-init)"
+      pattern: "first-use"
+---
+
+<objective>
+Livrer FIRST-01 + FIRST-02 : étendre l'agent `vibeflow-dev` (AGENT.md) d'un GARDE-FOU de
+premier usage. Avant de router une intention de dev (« code », « planifie », « teste »…) sur un
+projet qui n'est PAS GSD-initialisé (absence de `.planning/PROJECT.md` / `.planning/`), l'agent
+détecte l'absence (FIRST-01) et bascule sur la PROPOSITION d'init — cartographie du code existant
+puis démarrage de projet sur confirmation explicite, jamais `new-project` seul (FIRST-02,
+cohérent BOOT-04). La séquence d'init n'est PAS dupliquée : elle est déléguée au skill `vf-init`
+existant (qui porte déjà cette logique de proposition).
+
+Purpose: Sans ce garde-fou, demander « code ça » sur un dossier vierge route directement vers
+`gsd-execute-phase`, qui n'a ni feuille de route ni cadrage → échec ou travail dans le vide.
+Le garde-fou ferme le premier maillon du pipeline (init avant tout verbe structurant).
+
+Délimitation runtime (honnête) : le COMPORTEMENT effectif de l'agent (proposer plutôt que router)
+est de la prose validée en session réelle. Ce qui est TESTABLE l'est : la PRÉSENCE du garde-fou
+dans AGENT.md (détection `.planning`, délégation `vf-init`, interdiction `new-project` seul) est
+vérifiée par grep ; la commande de détection (`test -f .planning/PROJECT.md`) est documentée dans
+l'agent. La détection au sens « scriptable » se prouve par le check de fichier ; le routage
+conditionnel reste de la doctrine d'agent.
+
+Output:
+- `dev-orchestrator/AGENT.md` (étendu — garde-fou first-use, reste ≤250L)
+- `dev-orchestrator/scripts/tests/test-dev-orchestrator.sh` (étendu — axe T7)
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+# Spec — section 9 (dev-orchestrator first-use, ID7) + section 2 (décision ID7)
+@docs/superpowers/specs/2026-06-04-install-ux-design.md
+
+# Fichier à ÉTENDRE — agent routeur (frontmatter, table de routage, garde-fous, Iron Laws).
+# Calquer le style FR existant. Le garde-fou BOOT-04 (new-project jamais sans confirmation) est
+# DÉJÀ présent (§Garde-fous + Iron Law 4) : le first-use S'APPUIE dessus, ne le redéfinit pas.
+@dev-orchestrator/AGENT.md
+
+# Skill vf-init — porte DÉJÀ la séquence d'init (ensure-deps → map-codebase si code → new-project
+# sur confirmation, BOOT-04). RÉUTILISER : le garde-fou DÉLÈGUE à vf-init, ne réécrit pas la séquence.
+@dev-orchestrator/skills/vf-init/SKILL.md
+
+# Test du module à ÉTENDRE (ajout T7). Conventions à respecter :
+#   - set -uo pipefail, helpers ok()/ko()/skip(), compteurs pass/fail/skipped, exit [ "$fail" -eq 0 ].
+#   - $GREP = command -v grep (binaire système, immunisé à l'alias zsh ugrep).
+#   - $AGENT_FILE résolu en tête (source AGENT.md OU lab agents/dev-orchestrator.md) — RÉUTILISER.
+#   - T5 mesure déjà la densité AGENT.md ≤250L par wc -l : NE PAS dupliquer ce check dans T7.
+@dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
+
+<interfaces>
+<!-- Contrats existants à respecter (extraits du test et de l'agent). -->
+
+Conventions du test (déjà en place — RÉUTILISER, ne pas réintroduire) :
+  - GREP="$(command -v grep)"          # binaire système (alias zsh = ugrep)
+  - AGENT="$AGENT_FILE"                # résolu en tête : source OU lab installé
+  - ok "msg" / ko "msg" / skip "msg"   # incrémentent pass/fail/skipped
+  - Le bilan final fait `[ "$fail" -eq 0 ]` → tout nouvel axe doit incrémenter fail via ko().
+
+Hygiène grep-gate (T7) : compter sur fichier filtré des commentaires.
+  command grep -v '^#' "$AGENT" | command grep -ci 'first-use'   # PAS de == 0 sur fichier brut.
+
+vf-init (cible de délégation, à nommer textuellement dans AGENT.md) :
+  Skill `vf-init` — séquence : ensure-deps → (map-codebase si du code existe) → new-project
+  sur confirmation explicite. Le garde-fou first-use d'AGENT.md DÉLÈGUE à ce skill.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1 : Garde-fou first-use dans AGENT.md (détection `.planning/` + délégation vf-init), ≤250L</name>
+  <files>dev-orchestrator/AGENT.md</files>
+  <action>
+Étendre `dev-orchestrator/AGENT.md` d'un garde-fou de PREMIER USAGE, dans le style FR existant
+(concis, à l'essentiel). Ne PAS dupliquer la séquence d'init : DÉLÉGUER au skill `vf-init`.
+
+Ajouter une courte sous-section dédiée (titre du type `## Garde-fou premier usage (first-use)` ou
+`### Premier usage : projet non initialisé`), placée logiquement AVANT les heuristiques de routage
+ou en tête de la section Garde-fous. Contenu (3-6 lignes max, prose dense) :
+
+1. **Détection (FIRST-01)** : avant de router une intention de DEV structurante (« code »,
+   « planifie », « teste », « débugge »… — les verbes qui supposent un projet cadré), vérifier
+   que le projet est GSD-initialisé. Critère : présence de `.planning/PROJECT.md` (ou du dossier
+   `.planning/`). Donner la commande de détection explicitement, ex. `test -f .planning/PROJECT.md`.
+   Si ABSENT → projet non initialisé → ne PAS router le verbe de dev tout de suite.
+
+2. **Proposition (FIRST-02)** : dans ce cas, BASCULER sur le skill `vf-init` (le nommer
+   explicitement) — qui PROPOSE la cartographie du code existant (map-codebase, si du code existe)
+   puis le démarrage de projet (new-project) sur confirmation EXPLICITE. Préciser : ne JAMAIS
+   lancer `gsd-new-project` seul ni en autonomie (cohérent avec le garde-fou BOOT-04 déjà présent
+   et l'Iron Law 4). Réutiliser vf-init = ne pas réécrire la séquence ici.
+
+3. Reframe vocabulaire VibeFlow (cartographie du code / démarrage de projet) ; ne pas nommer GSD
+   ni Superpowers côté utilisateur (déjà la doctrine de l'agent).
+
+Mettre à jour la cohérence locale : optionnellement ajouter une puce dans `## Garde-fous` et/ou un
+anti-pattern (« ❌ Router une intention de dev sur un projet non initialisé sans proposer l'init »).
+NE PAS modifier la table de routage (≥11 intentions / cibles) — la cohérence T3 doit rester verte.
+Rester factuel : le nom de skill `vf-init` doit apparaître textuellement (lien testable).
+
+CONTRAINTE DENSITÉ (charte / T5) : `AGENT.md` doit rester ≤250 lignes (il est à 125L, marge large
+→ pas besoin de déporter en reference on-demand ; garder l'ajout compact malgré tout). Vérifier
+`wc -l` après édition.
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && A=dev-orchestrator/AGENT.md && n=$(wc -l < "$A" | tr -d " ") && test "$n" -le 250 && [ "$(command grep -v "^#" "$A" | command grep -ci "first-use\|premier usage")" -ge 1 ] && command grep -q "\.planning" "$A" && command grep -q "vf-init" "$A" && [ "$(command grep -v "^#" "$A" | command grep -ci "new-project")" -ge 1 ] && echo "OK-AGENT ${n}L"'</automated>
+  </verify>
+  <done>
+`AGENT.md` ≤250L contient une sous-section first-use qui : (a) nomme la détection par absence de
+`.planning/PROJECT.md` (FIRST-01) avec la commande `test -f .planning/PROJECT.md`, (b) délègue à
+`vf-init` la proposition map-codebase → new-project sur confirmation (FIRST-02), (c) interdit
+`new-project` seul (cohérent BOOT-04). La table de routage (≥11) reste intacte. La vérif imprime
+`OK-AGENT <n>L`.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2 : Axe T7 du test module — garde-fou first-use présent dans AGENT.md</name>
+  <files>dev-orchestrator/scripts/tests/test-dev-orchestrator.sh</files>
+  <action>
+Étendre `dev-orchestrator/scripts/tests/test-dev-orchestrator.sh` d'un nouvel axe **T7**
+(« garde-fou first-use présent dans AGENT.md »), inséré APRÈS T6, AVANT la ligne de bilan
+`echo "== résultat ..."`. Réutiliser les variables/helpers déjà en place : `$GREP`
+(= `command -v grep`), `$AGENT_FILE` (résolu en tête, source OU lab), `ok()/ko()`. NE PAS
+réintroduire de résolution d'agent ni de check de densité (T5 le fait déjà via wc -l).
+
+Mettre à jour le bandeau de commentaires en tête du fichier (la liste « T1…T6 ») pour documenter
+T7 (cohérence avec le style existant — une ligne `#   T7 — ...`).
+
+L'axe T7 vérifie la PRÉSENCE du garde-fou (FIRST-01 + FIRST-02) dans AGENT.md, sur fichier filtré
+des commentaires (hygiène grep-gate — éviter qu'un commentaire suffise) :
+  - `has_marker`  : `$GREP -v '^#' "$AGENT_FILE" | $GREP -ci 'first-use\|premier usage'` ≥ 1
+  - `has_detect`  : `$GREP -q -- '.planning' "$AGENT_FILE"` (détection projet non initialisé, FIRST-01)
+  - `has_vfinit`  : `$GREP -q -- 'vf-init' "$AGENT_FILE"` (délégation à la séquence d'init, pas de dup)
+  - `has_noauto`  : `$GREP -v '^#' "$AGENT_FILE" | $GREP -ci 'new-project'` ≥ 1
+    (référence à new-project — l'interdiction « jamais seul » BOOT-04, réaffirmée par le first-use)
+
+Si les quatre conditions sont vraies → `ok "T7 first-use : garde-fou présent (détection .planning + délégation vf-init + new-project encadré)"`.
+Sinon → `ko "T7 first-use : garde-fou incomplet dans AGENT.md (marker=$has_marker detect=$has_detect vfinit=$has_vfinit noauto=$has_noauto)"`
+(reporter les flags 0/1 pour diagnostiquer). Le ko() incrémente `fail`, donc le bilan final
+`[ "$fail" -eq 0 ]` casse si le garde-fou disparaît — c'est le but (test de régression FIRST-01/02).
+
+Robustesse zsh : invoquer le test via bash, utiliser `$GREP` (système) et le filtre `'^#'` comme
+les axes existants. Ne pas casser les autres axes (insertion isolée, pas de modification de T1–T6).
+  </action>
+  <verify>
+    <automated>/bin/bash -c 'cd /Users/samuel/Documents/dev/vibeflow-os && bash dev-orchestrator/scripts/tests/test-dev-orchestrator.sh; rc=$?; command grep -q "T7" dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && command grep -q "first-use" dev-orchestrator/scripts/tests/test-dev-orchestrator.sh && test $rc -eq 0 && echo "OK-TEST T7 vert"'</automated>
+  </verify>
+  <done>
+La suite `test-dev-orchestrator.sh` passe (exit 0) avec un axe T7 supplémentaire qui affiche
+`✓ T7 first-use ...` quand AGENT.md contient le garde-fou (détection `.planning` + délégation
+`vf-init` + new-project encadré), et bascule en `✗`/`fail` si l'un manque (régression FIRST-01/02).
+T1–T6 restent verts/SKIP inchangés. La vérif imprime `OK-TEST T7 vert`.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| agent ← état du dépôt (`.planning/`) | Décision de routage (router vs proposer l'init) basée sur la présence de fichiers locaux |
+| agent → utilisateur | L'agent propose une action d'init (jamais ne lance new-project seul) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-01 | Elevation of privilege | déclenchement automatique de `gsd-new-project` (interactif) | mitigate | Le garde-fou réaffirme BOOT-04 : new-project JAMAIS seul ni en autonomie, uniquement sur confirmation explicite (Iron Law 4) ; T7 vérifie que la mention reste présente |
+| T-06-02 | Tampering | `.planning/PROJECT.md` falsifiable (présent mais vide/invalide) | accept | Faible enjeu : un projet faussement « initialisé » saute juste la proposition d'init ; la doctrine d'agent (cadrage avant planif) rattrape en aval |
+| T-06-03 | Repudiation | la détection est de la prose d'agent, non un script bloquant | accept | Délimitation runtime assumée : la PRÉSENCE du garde-fou est testée (T7) ; le comportement effectif se valide en session réelle, comme le hook SessionStart de la phase 4 |
+</threat_model>
+
+<verification>
+- `wc -l dev-orchestrator/AGENT.md` ≤ 250 (charte densité, déjà couvert par T5 du module).
+- `command grep` sur AGENT.md (fichier filtré) : présence de `first-use`/`premier usage`, `.planning`,
+  `vf-init`, `new-project` → garde-fou FIRST-01 + FIRST-02 présent.
+- `bash dev-orchestrator/scripts/tests/test-dev-orchestrator.sh` → exit 0 ; T7 vert ; T1–T6 inchangés.
+- Note runtime (honnête) : le ROUTAGE CONDITIONNEL effectif (proposer l'init plutôt que router le
+  verbe de dev) se valide en session réelle. Ce plan rend testable ce qui l'est — la présence du
+  garde-fou dans la doctrine de l'agent et la commande de détection documentée.
+</verification>
+
+<success_criteria>
+- FIRST-01 : AGENT.md détecte un projet non GSD-initialisé au 1er usage via l'absence de
+  `.planning/PROJECT.md` (commande `test -f .planning/PROJECT.md` documentée), avant de router un
+  verbe de dev structurant.
+- FIRST-02 : AGENT.md propose map-codebase (si code) puis new-project sur confirmation, en
+  DÉLÉGUANT à `vf-init` (pas de duplication), et ne lance jamais `gsd-new-project` seul (BOOT-04).
+- AGENT.md reste ≤250L (T5) ; test du module étendu (T7) vert et régressif sur la disparition du
+  garde-fou ; T1–T6 inchangés.
+</success_criteria>
+
+<output>
+Après complétion, créer `.planning/phases/06-dev-orchestrator-first-use/06-01-SUMMARY.md`
+</output>

--- a/.planning/phases/06-dev-orchestrator-first-use/06-01-SUMMARY.md
+++ b/.planning/phases/06-dev-orchestrator-first-use/06-01-SUMMARY.md
@@ -1,0 +1,80 @@
+---
+phase: 06-dev-orchestrator-first-use
+plan: 01
+subsystem: dev-orchestrator
+tags: [agent, first-use, garde-fou, routing, vf-init]
+requires:
+  - "dev-orchestrator/AGENT.md (agent routeur vibeflow-dev)"
+  - "dev-orchestrator/skills/vf-init/SKILL.md (séquence d'init déléguée)"
+provides:
+  - "Garde-fou first-use dans AGENT.md : détection .planning absent + délégation vf-init avant routage d'un verbe de dev"
+  - "Axe de test T7 régressif sur la présence du garde-fou first-use"
+affects:
+  - "dev-orchestrator/AGENT.md"
+  - "dev-orchestrator/scripts/tests/test-dev-orchestrator.sh"
+tech-stack:
+  added: []
+  patterns:
+    - "grep-gate sur fichier filtré des commentaires (^#) pour éviter qu'un commentaire suffise"
+    - "délégation skill (pas de duplication de séquence) entre agent et vf-init"
+key-files:
+  created: []
+  modified:
+    - "dev-orchestrator/AGENT.md"
+    - "dev-orchestrator/scripts/tests/test-dev-orchestrator.sh"
+decisions:
+  - "Garde-fou placé AVANT la table de routage (point logique de décision router-vs-proposer)"
+  - "Séquence d'init NON dupliquée : le garde-fou délègue au skill vf-init existant"
+  - "Réaffirmation de BOOT-04 (new-project jamais seul) plutôt que redéfinition"
+metrics:
+  duration: "~1 min"
+  completed: "2026-06-04"
+requirements: [FIRST-01, FIRST-02]
+---
+
+# Phase 06 Plan 01 : Garde-fou first-use dev-orchestrator — Summary
+
+Garde-fou de premier usage ajouté à l'agent `vibeflow-dev` : avant de router une intention de dev structurante, l'agent détecte un projet non GSD-initialisé via l'absence de `.planning/PROJECT.md` (`test -f`, FIRST-01) et bascule sur le skill `vf-init` pour proposer cartographie puis démarrage de projet sur confirmation — jamais `gsd-new-project` seul (FIRST-02, BOOT-04). Axe de test T7 ajouté pour rendre la régression détectable.
+
+## Tasks réalisées
+
+| Task | Nom | Commit | Fichiers |
+| ---- | --- | ------ | -------- |
+| 1 | Garde-fou first-use dans AGENT.md (détection `.planning` + délégation vf-init), ≤250L | `3db8acf` | `dev-orchestrator/AGENT.md` |
+| 2 | Axe T7 du test module — garde-fou first-use présent dans AGENT.md | `3298305` | `dev-orchestrator/scripts/tests/test-dev-orchestrator.sh` |
+
+## Détail
+
+### Task 1 — Garde-fou first-use (AGENT.md)
+- Nouvelle sous-section `## Garde-fou premier usage (first-use)` placée AVANT la table de routage.
+- (a) Détection FIRST-01 : critère `.planning/PROJECT.md`, commande `test -f .planning/PROJECT.md`.
+- (b) Proposition FIRST-02 : délégation explicite au skill `vf-init` (cartographie si code → démarrage sur confirmation), jamais `gsd-new-project` seul ni en autonomie (BOOT-04 / Iron Law 4).
+- Cohérence locale : puce ajoutée dans `## Garde-fous` + anti-pattern « router une intention de dev sur un projet non initialisé sans proposer l'init ».
+- Table de routage (≥11 intentions/cibles) intacte — T3 reste verte.
+- Densité : AGENT.md = 143L (≤250, T5). Vérif imprime `OK-AGENT 143L`.
+
+### Task 2 — Axe T7 (test du module)
+- T7 inséré APRÈS T6, AVANT le bilan `echo "== résultat ..."`.
+- Réutilise `$GREP` (binaire système, immunisé alias zsh ugrep), `$AGENT_FILE` (résolu en tête source/lab), `ok()`/`ko()`.
+- 4 conditions sur fichier filtré `'^#'` : `has_marker` (first-use/premier usage), `has_detect` (`.planning`), `has_vfinit` (`vf-init`), `has_noauto` (`new-project`). `ko()` reporte les flags 0/1 et casse le bilan `[ "$fail" -eq 0 ]` si le garde-fou disparaît.
+- Bandeau d'en-tête mis à jour (ligne `#   T7 — ...`).
+- Aucun check de densité dupliqué (T5 le porte déjà).
+
+## Verification
+
+- Task 1 : `OK-AGENT 143L` (≤250, garde-fou présent : `.planning`, `vf-init`, `new-project`, marker first-use).
+- Task 2 : suite complète `bash test-dev-orchestrator.sh` → **13 OK / 0 KO / 0 SKIP**, exit 0. `OK-TEST T7 vert`. T1–T6 inchangés.
+- Note runtime (assumée) : le routage conditionnel effectif (proposer l'init plutôt que router) reste de la doctrine d'agent ; le plan rend testable la PRÉSENCE du garde-fou (T7) et documente la commande de détection.
+
+## Deviations from Plan
+
+None - plan exécuté exactement comme écrit.
+
+## Self-Check: PASSED
+
+- FOUND: dev-orchestrator/AGENT.md (modifié, 143L)
+- FOUND: dev-orchestrator/scripts/tests/test-dev-orchestrator.sh (modifié, T7 présent)
+- FOUND: commit 3db8acf (Task 1)
+- FOUND: commit 3298305 (Task 2)
+</content>
+</invoke>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,167 +1,112 @@
 # INSTALL — vibeflow-os
 
-> Guide d'installation des modules vibeflow-os dans un lab existant.
+> Guide d'installation de VibeFlow comme **plugin Claude Code**.
 
 ---
 
 ## Pré-requis
 
-- Accès en lecture au repo `picmakpro/vibeflow-os` (privé) via `gh CLI` ou SSH key
-- Lab cible avec structure standard : `.claude/skills/`, `.claude/scripts/`, `.claude/memory/`
-- `bash 4+`, `python3 3.8+`, `awk`, `grep`, `sed` (macOS/Linux)
+- **Claude Code** à jour (commande `claude plugin` disponible).
+- `bash 4+`, `python3 3.8+`, `awk`, `grep`, `sed` (macOS/Linux) — utilisés par l'engine bundlé.
+
+Aucun accès privé, aucun clone, aucune auth `gh` ne sont requis pour installer le plugin.
 
 ---
 
-## Méthode 1 — Install via script vibeflow-update.sh (recommandée)
-
-### Étape 1 — Cloner le repo en cache local
+## Installation (2 commandes)
 
 ```bash
-cd /chemin/vers/votre-lab
-git clone --depth 1 https://github.com/picmakpro/vibeflow-os.git .vibeflow-cache
+claude plugin marketplace add picmakpro/vibeflow-os
+claude plugin install vibeflow
 ```
 
-Le dossier `.vibeflow-cache/` doit être ajouté à `.gitignore` du lab (c'est un cache, pas du code de projet).
+- La 1ère commande ajoute le marketplace VibeFlow (le repo GitHub `picmakpro/vibeflow-os` héberge
+  son propre `marketplace.json`).
+- La 2nde installe le plugin `vibeflow` : Claude Code copie le bundle (modules + skill `installer/`
+  + engine `_internal/` + hook) dans son cache local de plugins.
 
-### Étape 2 — Installer le script vibeflow-update.sh
-
-```bash
-mkdir -p .claude/scripts
-cp .vibeflow-cache/_internal/vibeflow-update.sh .claude/scripts/
-chmod +x .claude/scripts/vibeflow-update.sh
-```
-
-### Étape 3 — Installer un module
-
-```bash
-.claude/scripts/vibeflow-update.sh install consolidator
-```
-
-Cela copie :
-- `.vibeflow-cache/consolidator/SKILL.md` → `.claude/skills/consolidator/SKILL.md`
-- `.vibeflow-cache/consolidator/references/` → `.claude/skills/consolidator/references/`
-- `.vibeflow-cache/consolidator/scripts/*.sh` → `.claude/scripts/`
-- Crée `.claude/scripts/.vibeflow-installed` (registre des modules installés)
-
-### Étape 4 — Configurer les hooks (optionnel mais recommandé)
-
-Le module `consolidator` propose un hook `SessionEnd` async qui appelle `archive.sh`. Pour l'activer, ajouter dans `.claude/settings.json` ou `settings.local.json` :
-
-```json
-"hooks": {
-  "SessionEnd": [{
-    "hooks": [{
-      "type": "command",
-      "command": "test -x .claude/scripts/archive.sh && .claude/scripts/archive.sh --async --threshold-days=90 >/dev/null 2>&1 &"
-    }]
-  }]
-}
-```
-
-Voir `.vibeflow-cache/consolidator/SKILL.md` pour les autres hooks proposés.
+Aucune édition de `settings.json`, aucun script à lancer manuellement.
 
 ---
 
-## Méthode 2 — Install manuelle (sans script)
+## Auto-lancement (1er lancement)
 
-Si tu préfères contrôler chaque copie :
+Charger un plugin équivaut à un restart de Claude Code. À la **session suivante**, le hook
+`SessionStart` du plugin détecte qu'aucun marqueur `scripts/.vibeflow-installed` n'existe → il
+ouvre **automatiquement** l'UX `/vibeflow-install` :
 
-```bash
-git clone --depth 1 https://github.com/picmakpro/vibeflow-os.git /tmp/vibeflow-os
-cp -r /tmp/vibeflow-os/consolidator/SKILL.md .claude/skills/consolidator/
-cp -r /tmp/vibeflow-os/consolidator/references .claude/skills/consolidator/
-cp /tmp/vibeflow-os/consolidator/scripts/*.sh .claude/scripts/
-chmod +x .claude/scripts/*.sh
-```
+1. **Toggle scope** (single-select) : compte (`user`) / projet (`project`) / projet sans commit
+   (`local`). Le scope choisi s'applique partout (modules VibeFlow + dépendances).
+2. **Toggle modules** (multi-select) : la liste est peuplée depuis le catalogue (chaque module +
+   sa description 1 ligne).
+3. **Auto-résolution + récap** : la fermeture transitive des `requires` est calculée et
+   **récapitulée** avant toute install.
+4. **Install scopée** : les modules sélectionnés sont posés au scope choisi.
+
+Une fois l'install terminée, le marqueur est posé et l'auto-lancement ne se redéclenche plus.
+
+### Re-configurer / ajouter un module
+
+`/vibeflow-install` reste invocable à la main pour changer de scope, ajouter ou retirer un module ;
+les dépendances sont re-résolues automatiquement à chaque passage.
 
 ---
 
 ## Mises à jour
 
-### Vérifier les versions disponibles
-
 ```bash
-.claude/scripts/vibeflow-update.sh status
+claude plugin update vibeflow
 ```
 
-Sortie type :
-```
-Module           Installed  Available  Status
-consolidator     v1.0.0     v1.0.1     Update available
-infrastructure-  -          v1.0.0     Not installed
-```
-
-### Update un module
-
-```bash
-.claude/scripts/vibeflow-update.sh update consolidator
-```
-
-Le script :
-1. Tire les derniers commits du cache `.vibeflow-cache/`
-2. Backup l'installation actuelle dans `.claude/.backups/`
-3. Copie les nouveaux fichiers
-4. Met à jour `.claude/scripts/.vibeflow-installed`
-
-### Update tous
-
-```bash
-.claude/scripts/vibeflow-update.sh update --all
-```
-
-### Rollback
-
-```bash
-.claude/scripts/vibeflow-update.sh rollback consolidator
-```
+Récupère la dernière version publiée du plugin depuis le marketplace, puis re-passer par
+`/vibeflow-install` si tu veux activer de nouveaux modules apparus dans le catalogue.
 
 ---
 
-## Désinstallation d'un module
+## Désinstallation
 
 ```bash
-.claude/scripts/vibeflow-update.sh uninstall consolidator
+claude plugin uninstall vibeflow
 ```
 
-Le script supprime les fichiers installés et l'entrée dans `.vibeflow-installed`. Le cache `.vibeflow-cache/` reste intact (utile pour re-installer plus tard).
+Cela retire le plugin (skill + hook + bundle) du cache de Claude Code. Les modules déjà copiés
+dans un scope (`.claude/skills/`, `.claude/agents/`, etc.) restent en place ; les retirer
+manuellement si besoin.
 
 ---
 
 ## Sécurité
 
-- Tous les scripts sont **idempotents** (peuvent être ré-exécutés sans casser l'installation)
-- Tous les `--apply` créent un backup automatique
-- Les modules sont **distribués en lecture seule** (le script `vibeflow-update.sh` ne pousse jamais de modifications vers le repo central)
-- Pour proposer une modification : fork + PR sur `picmakpro/vibeflow-os`
+- L'engine et les modules sont des scripts **shell + Python** auditables ligne par ligne.
+- Tous les scripts d'install sont **idempotents** (ré-exécutables sans casser l'installation).
+- Les copies créent un backup automatique avant écrasement.
+- Le hook `SessionStart` ne fait que **lire** un marqueur et émettre du JSON : aucune écriture,
+  aucun effet de bord.
 
 ---
 
 ## Troubleshooting
 
-### "Permission denied" sur scripts
+### `claude plugin` introuvable
+
+Mettre Claude Code à jour : la commande `plugin` doit être disponible.
+
+### Le plugin ne s'auto-lance pas
+
+L'auto-lancement se déclenche à la **session suivant** l'install (restart). Vérifier qu'aucun
+marqueur `scripts/.vibeflow-installed` n'existe déjà (sinon le hook reste volontairement
+silencieux). On peut toujours lancer `/vibeflow-install` à la main.
+
+### Le marketplace n'est pas trouvé
 
 ```bash
-chmod +x .claude/scripts/*.sh .claude/scripts/tests/*.sh
+claude plugin marketplace add picmakpro/vibeflow-os
+claude plugin marketplace list
 ```
 
-### Cache désynchronisé
+### Réinstaller le plugin
 
 ```bash
-rm -rf .vibeflow-cache
-git clone --depth 1 https://github.com/picmakpro/vibeflow-os.git .vibeflow-cache
-```
-
-### Module corrompu
-
-```bash
-.claude/scripts/vibeflow-update.sh rollback <module>
-# OU
-.claude/scripts/vibeflow-update.sh reinstall <module>
-```
-
-### Auth GitHub échoue
-
-```bash
-gh auth status
-gh auth login  # si nécessaire
+claude plugin uninstall vibeflow
+claude plugin install vibeflow
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vibeflow-os
 
 > **Modules VibeFlow distribués aux labs** — repo central versionné pour réplication méthodologique.
-> Privé. Maintenu par [@picmakpro](https://github.com/picmakpro).
+> Public (source-available, licence propriétaire). Maintenu par [@picmakpro](https://github.com/picmakpro).
 
 ---
 
@@ -102,7 +102,7 @@ Chaque module a sa propre version. Le repo global est tagué à la version du de
 
 ## Sécurité
 
-- Repo privé
+- Repo public **source-available** : code et historique visibles, licence propriétaire « All rights reserved » (aucun droit de réutilisation accordé)
 - Scripts shell + Python uniquement (auditables ligne par ligne)
 - Pas de dépendances tierces non vérifiées
 - Tests automatisés pour chaque script (`scripts/tests/test-*.sh`)

--- a/README.md
+++ b/README.md
@@ -38,41 +38,42 @@ Chaque module a obligatoirement : `VERSION` (semver), `CHANGELOG.md`, `README.md
 
 ---
 
-## Installation dans un lab
+## Installation
 
-### Première installation
-
-```bash
-cd /chemin/vers/votre-lab
-git clone --depth 1 https://github.com/picmakpro/vibeflow-os.git .vibeflow-cache
-cp .vibeflow-cache/_internal/vibeflow-update.sh .claude/scripts/
-chmod +x .claude/scripts/vibeflow-update.sh
-.claude/scripts/vibeflow-update.sh install --all
-```
-
-### Installer un module spécifique
+VibeFlow s'installe comme **plugin Claude Code**, en deux commandes :
 
 ```bash
-.claude/scripts/vibeflow-update.sh install consolidator
-.claude/scripts/vibeflow-update.sh install skill-creator
-.claude/scripts/vibeflow-update.sh install reference
+claude plugin marketplace add picmakpro/vibeflow-os
+claude plugin install vibeflow
 ```
 
-### Status / mises à jour
+Aucun clone, aucun script à lancer, aucune édition de `settings.json`.
+
+### Auto-lancement (1er lancement)
+
+À la **session suivante** (charger un plugin = restart de Claude Code), le hook `SessionStart`
+détecte le 1er lancement — le marqueur `scripts/.vibeflow-installed` est absent — et **ouvre
+automatiquement** l'UX `/vibeflow-install` :
+
+- **Toggle scope** (single-select) : compte (`user`) / projet (`project`) / projet sans commit (`local`).
+- **Toggle modules** (multi-select) : la liste sort du catalogue (chaque module + sa description).
+- **Dépendances auto-résolues** : la fermeture transitive des `requires` est calculée et récapitulée
+  avant toute install.
+
+Une fois VibeFlow installé, ce message ne réapparaît plus.
+
+### Re-configurer / ajouter un module
+
+`/vibeflow-install` reste invocable à la main à tout moment pour changer de scope, ajouter ou
+retirer un module (les dépendances sont re-résolues automatiquement).
+
+### Mise à jour
 
 ```bash
-.claude/scripts/vibeflow-update.sh status
-.claude/scripts/vibeflow-update.sh update consolidator
-.claude/scripts/vibeflow-update.sh update --all
+claude plugin update vibeflow
 ```
 
-### Rollback
-
-```bash
-.claude/scripts/vibeflow-update.sh rollback consolidator
-```
-
-Voir [INSTALL.md](./INSTALL.md) pour les détails.
+Voir [INSTALL.md](./INSTALL.md) pour les détails (désinstallation, troubleshooting).
 
 ---
 

--- a/_internal/resolve-deps.sh
+++ b/_internal/resolve-deps.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# resolve-deps.sh — Résolveur de fermeture transitive des `requires` des module.json.
+#
+# Usage : resolve-deps.sh <module> [<module> ...]
+#   Donné une ou plusieurs racines, suit récursivement le champ `requires` de chaque
+#   module.json, et émet sur stdout la fermeture transitive (entrées d'origine + toutes
+#   leurs deps), triée alphabétiquement et dédupliquée, un module par ligne.
+#
+# Racine des modules : ${VF_MODULES_ROOT:-<parent du dossier du script>}.
+#   Surchargeable via VF_MODULES_ROOT pour injecter des fixtures de test.
+#
+# Erreurs : module.json absent (module inconnu) → message sur stderr + exit non-zéro.
+# Sécurité : marquage « vu » avant enfilage des deps → terminaison garantie même en cas de cycle.
+set -euo pipefail
+
+log() { echo "[resolve-deps] $*" >&2; }
+err() { echo "[resolve-deps] ERROR: $*" >&2; exit 1; }
+
+ROOT="${VF_MODULES_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+[ "$#" -ge 1 ] || err "usage: resolve-deps.sh <module> [<module> ...]"
+
+# File de travail (BFS) + set des modules vus.
+queue=("$@")
+seen=""
+
+is_seen() { case " $seen " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+while [ "${#queue[@]}" -gt 0 ]; do
+  mod="${queue[0]}"
+  queue=("${queue[@]:1}")
+
+  is_seen "$mod" && continue
+  seen="$seen $mod"
+
+  manifest="$ROOT/$mod/module.json"
+  [ -f "$manifest" ] || err "module inconnu : '$mod' (manifeste absent : $manifest)"
+
+  # Enfiler les requires non encore vus.
+  while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    is_seen "$dep" || queue+=("$dep")
+  done < <(jq -r '.requires[]?' "$manifest")
+done
+
+# Émettre la fermeture : un par ligne, triée, dédupliquée.
+printf '%s\n' $seen | sort -u

--- a/_internal/tests/test-resolve-deps.sh
+++ b/_internal/tests/test-resolve-deps.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Test de resolve-deps.sh — autonome (pointe sur les vrais module.json du repo via VF_MODULES_ROOT)
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/resolve-deps.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+export VF_MODULES_ROOT="$REPO_ROOT"
+
+pass=0; fail=0
+ok()   { echo "  ✓ $1"; pass=$((pass+1)); }
+ko()   { echo "  ✗ $1"; fail=$((fail+1)); }
+
+echo "== test-resolve-deps =="
+
+# 1. validator → fermeture transitive {consolidator, infrastructure-audit, validator} (triée, 3 lignes)
+out=$(bash "$SCRIPT" validator 2>/dev/null)
+exp=$(printf 'consolidator\ninfrastructure-audit\nvalidator')
+[ "$out" = "$exp" ] && ok "validator → consolidator, infrastructure-audit, validator (3 lignes triées)" \
+  || ko "validator: attendu [$exp] obtenu [$out]"
+
+# 2. consolidator (sans requires) → lui-même seul (1 ligne)
+out=$(bash "$SCRIPT" consolidator 2>/dev/null)
+[ "$out" = "consolidator" ] && ok "consolidator → consolidator seul (1 ligne)" \
+  || ko "consolidator: attendu [consolidator] obtenu [$out]"
+
+# 3. validator consolidator → pas de doublon (consolidator une seule fois)
+out=$(bash "$SCRIPT" validator consolidator 2>/dev/null)
+n=$(printf '%s\n' "$out" | grep -c '^consolidator$')
+[ "$n" -eq 1 ] && ok "validator consolidator → consolidator non dupliqué" \
+  || ko "doublon: consolidator apparaît $n fois"
+
+# 4. module inconnu → exit non-zéro
+bash "$SCRIPT" module-inexistant-xyz >/dev/null 2>&1
+[ $? -ne 0 ] && ok "module inconnu → exit non-zéro" \
+  || ko "module inconnu devrait échouer (exit non-zéro)"
+
+# 5. sortie triée alphabétiquement (consolidator < infrastructure-audit < validator)
+out=$(bash "$SCRIPT" validator 2>/dev/null)
+sorted=$(printf '%s\n' "$out" | sort)
+[ "$out" = "$sorted" ] && ok "sortie triée alphabétiquement" \
+  || ko "sortie non triée: [$out]"
+
+echo "== résultat : $pass OK / $fail KO =="
+[ "$fail" -eq 0 ]

--- a/_internal/tests/test-vibeflow-update.sh
+++ b/_internal/tests/test-vibeflow-update.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# test-vibeflow-update.sh — Suite de vérification de l'engine scope-aware (Phase 03-01).
+#
+# Couvre les 5 truths du plan, en ISOLATION TOTALE (HOME + cache mktemp) :
+#   T1 (user)    — VF_SCOPE=user install dev-orchestrator → artefacts sous $HOME/.claude,
+#                  RIEN sous ./.claude du lab.
+#   T2 (project) — sans VF_SCOPE (défaut LEGACY project), install → artefacts sous ./.claude
+#                  du lab ; rétro-compat dev-orchestrator (agent + references D7 présents).
+#   T3 (local)   — VF_SCOPE=local install → ./.gitignore du lab contient les chemins ;
+#                  2e run = pas de doublon (idempotent, grep -c == 1).
+#   T4 (no clone)— aucun `git clone`/`git pull` dans le source de l'engine (assert statique).
+#   T5 (résolveur RÉELLEMENT exercé) — resolve-deps.sh copié dans $CACHE/_internal/, puis
+#                  install --with-deps validator → fermeture {consolidator, infrastructure-audit,
+#                  validator} installée. SKIP propre seulement si les module.json manquent
+#                  (JAMAIS pour résolveur absent — on le copie).
+#
+# En prod, Phase 5 (PLUG-02) bundle resolve-deps.sh dans le cache du plugin ; ce test reproduit
+# ce bundling en copiant le résolveur dans $CACHE/_internal/.
+#
+# ISOLATION : le vrai ~/.claude n'est JAMAIS touché. Défense principale = HOME=mktemp pour le
+# scope user. Ceinture+bretelles = snapshot RÉCURSIF (find -type f) du vrai ~/.claude avant/après.
+#
+# Convention : asserts numérotés, helpers ok()/ko()/skip(), exit 0 si tout passe (SKIP non
+# bloquant), exit 1 si au moins un KO. Calqué sur le pattern de test du repo.
+
+set -uo pipefail
+
+# Racines (test sous _internal/tests/ → engine et modules sous _internal/.. = REPO).
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTERNAL_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+REPO="$(cd "$INTERNAL_DIR/.." && pwd)"
+INSTALLER="$INTERNAL_DIR/vibeflow-update.sh"
+RESOLVER="$INTERNAL_DIR/resolve-deps.sh"
+
+pass=0; fail=0; skipped=0
+ok()   { echo "  ✓ $1"; pass=$((pass+1)); }
+ko()   { echo "  ✗ $1"; fail=$((fail+1)); }
+skip() { echo "  ⊘ SKIP $1"; skipped=$((skipped+1)); }
+
+# grep insensible à l'alias zsh (ugrep) : on force le binaire système.
+GREP="$(command -v grep)"
+
+echo "== test-vibeflow-update (engine: $INSTALLER) =="
+
+# Snapshot RÉCURSIF du vrai ~/.claude AVANT la suite (garde-fou anti-pollution).
+HOME_BEFORE=$(find "$HOME/.claude" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+# Helper : prépare un cache de test avec un module copié depuis le repo.
+# Usage : prepare_module <cache_dir> <module>
+prepare_module() {
+  local cache="$1" mod="$2"
+  mkdir -p "$cache/$mod"
+  cp -r "$REPO/$mod/." "$cache/$mod/" 2>/dev/null || return 1
+  [ -f "$cache/$mod/VERSION" ] || return 1
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# T1 (user) — install sous $HOME/.claude, RIEN sous ./.claude du lab
+# ---------------------------------------------------------------------------
+LAB="$(mktemp -d)"
+CACHE="$LAB/cache"
+FAKE_HOME="$LAB/home"
+mkdir -p "$FAKE_HOME"
+if prepare_module "$CACHE" "dev-orchestrator"; then
+  (cd "$LAB" && HOME="$FAKE_HOME" VF_SCOPE=user VIBEFLOW_CACHE="$CACHE" \
+     bash "$INSTALLER" install dev-orchestrator >/dev/null 2>&1)
+  miss=0
+  [ -f "$FAKE_HOME/.claude/agents/dev-orchestrator.md" ] \
+    || { ko "T1 user : \$HOME/.claude/agents/dev-orchestrator.md manquant"; miss=1; }
+  # RIEN ne doit apparaître sous ./.claude du lab (cwd projet).
+  if [ -d "$LAB/.claude" ]; then
+    ko "T1 user : ./.claude présent dans le lab (devrait être vide — scope user → \$HOME)"
+    miss=1
+  fi
+  [ "$miss" -eq 0 ] && ok "T1 user : agent écrit sous \$HOME/.claude, rien sous ./.claude du lab"
+else
+  skip "T1 user : dev-orchestrator non copiable dans le cache de test"
+fi
+rm -rf "$LAB"
+
+# ---------------------------------------------------------------------------
+# T2 (project défaut) — install sous ./.claude du lab ; rétro-compat D7
+# ---------------------------------------------------------------------------
+LAB="$(mktemp -d)"
+CACHE="$LAB/cache"
+if prepare_module "$CACHE" "dev-orchestrator"; then
+  # Sans VF_SCOPE : défaut LEGACY project → ./.claude (comportement historique).
+  (cd "$LAB" && VIBEFLOW_CACHE="$CACHE" \
+     bash "$INSTALLER" install dev-orchestrator >/dev/null 2>&1)
+  miss=0
+  [ -f "$LAB/.claude/agents/dev-orchestrator.md" ] \
+    || { ko "T2 project : ./.claude/agents/dev-orchestrator.md manquant"; miss=1; }
+  # Rétro-compat references D7 (au moins les 3 references canoniques).
+  for ref in GSD-PIPELINE.md gsd-skills-index.md vocabulary-map.md; do
+    [ -f "$LAB/.claude/agents/dev-orchestrator-references/$ref" ] \
+      || { ko "T2 project : references/$ref manquant (rétro-compat D7)"; miss=1; }
+  done
+  [ "$miss" -eq 0 ] && ok "T2 project : artefacts sous ./.claude du lab (agent + references D7 présents)"
+else
+  skip "T2 project : dev-orchestrator non copiable dans le cache de test"
+fi
+rm -rf "$LAB"
+
+# ---------------------------------------------------------------------------
+# T3 (local → gitignore idempotent)
+# ---------------------------------------------------------------------------
+LAB="$(mktemp -d)"
+CACHE="$LAB/cache"
+if prepare_module "$CACHE" "dev-orchestrator"; then
+  (cd "$LAB" && VF_SCOPE=local VIBEFLOW_CACHE="$CACHE" \
+     bash "$INSTALLER" install dev-orchestrator >/dev/null 2>&1)
+  # 2e run : doit rester idempotent (pas de doublon).
+  (cd "$LAB" && VF_SCOPE=local VIBEFLOW_CACHE="$CACHE" \
+     bash "$INSTALLER" install dev-orchestrator >/dev/null 2>&1)
+  miss=0
+  if [ ! -f "$LAB/.gitignore" ]; then
+    ko "T3 local : ./.gitignore non créé"
+    miss=1
+  else
+    # Le chemin de l'agent dev-orchestrator doit être présent exactement une fois.
+    n=$("$GREP" -cxF ".claude/agents/dev-orchestrator.md" "$LAB/.gitignore" || true)
+    [ "${n:-0}" -eq 1 ] \
+      || { ko "T3 local : .claude/agents/dev-orchestrator.md apparaît $n fois (attendu 1, idempotence)"; miss=1; }
+  fi
+  [ "$miss" -eq 0 ] && ok "T3 local : .gitignore contient le chemin agent, sans doublon après 2 runs (idempotent)"
+else
+  skip "T3 local : dev-orchestrator non copiable dans le cache de test"
+fi
+rm -rf "$LAB"
+
+# ---------------------------------------------------------------------------
+# T4 (no clone) — assert statique sur le source de l'engine
+# ---------------------------------------------------------------------------
+if "$GREP" -nE 'git clone|git pull' "$INSTALLER" >/dev/null 2>&1; then
+  ko "T4 no-clone : 'git clone'/'git pull' encore présent dans l'engine"
+else
+  ok "T4 no-clone : aucun 'git clone'/'git pull' dans l'engine (source = cache fourni)"
+fi
+
+# ---------------------------------------------------------------------------
+# T5 (résolveur RÉELLEMENT exercé) — fermeture transitive de validator
+# ---------------------------------------------------------------------------
+# En prod, Phase 5 (PLUG-02) bundle resolve-deps.sh dans le cache du plugin ; ce test
+# reproduit ce bundling en copiant le résolveur dans $CACHE/_internal/.
+LAB="$(mktemp -d)"
+CACHE="$LAB/cache"
+CLOSURE="validator consolidator infrastructure-audit"
+copy_ok=1
+for m in $CLOSURE; do
+  prepare_module "$CACHE" "$m" || { copy_ok=0; break; }
+  [ -f "$CACHE/$m/module.json" ] || { copy_ok=0; break; }
+done
+if [ "$copy_ok" -eq 0 ]; then
+  skip "T5 résolveur : module.json de validator/consolidator/infrastructure-audit non copiables"
+elif [ ! -f "$RESOLVER" ]; then
+  skip "T5 résolveur : resolve-deps.sh introuvable dans le repo ($RESOLVER)"
+else
+  # Copier le résolveur RÉEL dans le cache → resolve_closure le trouve et l'EXÉCUTE
+  # (pas le fallback bruyant). C'est le chemin nominal de prod (PLUG-02).
+  mkdir -p "$CACHE/_internal"
+  cp "$RESOLVER" "$CACHE/_internal/resolve-deps.sh"
+  (cd "$LAB" && VF_SCOPE=project VIBEFLOW_CACHE="$CACHE" \
+     bash "$INSTALLER" install --with-deps validator >/dev/null 2>&1)
+  miss=0
+  # Fermeture installée : validator (agent), consolidator (skill), infrastructure-audit (skill).
+  [ -f "$LAB/.claude/agents/validator.md" ] \
+    || { ko "T5 résolveur : validator (agent) non installé"; miss=1; }
+  [ -f "$LAB/.claude/skills/consolidator/SKILL.md" ] \
+    || { ko "T5 résolveur : consolidator (dépendance) non installé"; miss=1; }
+  [ -f "$LAB/.claude/skills/infrastructure-audit/SKILL.md" ] \
+    || { ko "T5 résolveur : infrastructure-audit (dépendance) non installé"; miss=1; }
+  [ "$miss" -eq 0 ] \
+    && ok "T5 résolveur : --with-deps validator installe la fermeture {validator, consolidator, infrastructure-audit} (résolveur RÉELLEMENT exercé)"
+fi
+rm -rf "$LAB"
+
+# ---------------------------------------------------------------------------
+# Garde-fou final : le vrai ~/.claude est inchangé (snapshot récursif avant=après).
+# ---------------------------------------------------------------------------
+HOME_AFTER=$(find "$HOME/.claude" -type f 2>/dev/null | wc -l | tr -d ' ')
+if [ "$HOME_BEFORE" = "$HOME_AFTER" ]; then
+  ok "Garde-fou : ~/.claude intact ($HOME_AFTER fichiers récursifs avant=après)"
+else
+  ko "Garde-fou : ~/.claude POLLUÉ (avant=$HOME_BEFORE, après=$HOME_AFTER)"
+fi
+
+# ---------------------------------------------------------------------------
+echo "== résultat : $pass OK / $fail KO / $skipped SKIP =="
+[ "$fail" -eq 0 ]

--- a/_internal/vibeflow-update.sh
+++ b/_internal/vibeflow-update.sh
@@ -1,45 +1,93 @@
 #!/usr/bin/env bash
-# vibeflow-update.sh — Installeur/updateur des modules vibeflow-os dans un lab
+# vibeflow-update.sh — Installeur/updateur scope-aware des modules vibeflow-os.
 #
 # Usage:
-#   ./vibeflow-update.sh install <module>          # Installe un module
-#   ./vibeflow-update.sh install --all             # Installe tous les modules dispo
-#   ./vibeflow-update.sh update <module>           # Met à jour un module installé
-#   ./vibeflow-update.sh update --all              # Met à jour tous les modules installés
-#   ./vibeflow-update.sh uninstall <module>        # Désinstalle un module
-#   ./vibeflow-update.sh rollback <module>         # Restore depuis backup
-#   ./vibeflow-update.sh status                    # Liste modules installés + versions
-#   ./vibeflow-update.sh sync                      # Re-tire le cache depuis le repo central
+#   ./vibeflow-update.sh [--scope user|project|local] install <module>      # Installe un module
+#   ./vibeflow-update.sh [--scope ...] install --with-deps <module>         # Installe la fermeture transitive
+#   ./vibeflow-update.sh [--scope ...] install --all                        # Installe tous les modules dispo
+#   ./vibeflow-update.sh [--scope ...] update <module>                      # Met à jour un module installé
+#   ./vibeflow-update.sh [--scope ...] update --all                         # Met à jour tous les modules installés
+#   ./vibeflow-update.sh [--scope ...] uninstall <module>                   # Désinstalle un module
+#   ./vibeflow-update.sh [--scope ...] rollback <module>                    # Restore depuis backup
+#   ./vibeflow-update.sh [--scope ...] status                               # Liste modules installés + versions
+#   ./vibeflow-update.sh sync                                               # No-op (source = cache, plus de git)
 #
-# Pré-requis : .vibeflow-cache/ existe (git clone du repo picmakpro/vibeflow-os)
-# Sinon : git clone --depth 1 https://github.com/picmakpro/vibeflow-os.git .vibeflow-cache
+# Source : le cache local fourni par l'appelant (VIBEFLOW_CACHE, défaut .vibeflow-cache).
+#   Plus de clone/pull git : le cache DOIT exister (sinon erreur). En prod, c'est le skill
+#   /vibeflow-install (Phase 4) qui prépare le cache à partir du plugin packagé (Phase 5).
+#
+# Scope (cible d'install, spec §3) :
+#   --scope user            → $HOME/.claude
+#   --scope project | local → ./.claude   (local ajoute en plus les chemins au ./.gitignore)
+#   env VF_SCOPE            → idem ; --scope l'emporte sur VF_SCOPE.
+#
+# Pré-requis : $VIBEFLOW_CACHE existe (dossier des modules + leurs module.json).
 
 set -euo pipefail
 
-CACHE_DIR="${VIBEFLOW_CACHE:-.vibeflow-cache}"
-INSTALLED_REGISTRY=".claude/scripts/.vibeflow-installed"
-BACKUP_DIR=".claude/.backups"
-REPO_URL="https://github.com/picmakpro/vibeflow-os.git"
-
-# ---------- Helpers ----------
+# ---------- Helpers (définis tôt : utilisés dès le parsing) ----------
 log() { echo "[vibeflow-update] $*" >&2; }
 err() { echo "[vibeflow-update] ERROR: $*" >&2; exit 1; }
 
-ensure_cache() {
-  if [ ! -d "$CACHE_DIR" ]; then
-    log "Cache $CACHE_DIR absent. Clone du repo..."
-    git clone --depth 1 "$REPO_URL" "$CACHE_DIR" 2>&1 | tail -5
-  fi
-}
+# ---------- Résolution du scope → TARGET_ROOT (SCOPE-01) ----------
+# Défaut LEGACY = `project` (cible historique ./.claude). C'est un fallback APPEL-DIRECT
+# (debug, run manuel, tests). EN PROD le skill /vibeflow-install (Phase 4) passe TOUJOURS un
+# VF_SCOPE explicite à l'engine ET à ensure-deps.sh (un seul scope partout — cohérence ID4,
+# spec §3/§8). Ce défaut engine `project` ne co-occurre donc JAMAIS en prod avec le défaut
+# LEGACY `user` de ensure-deps.sh : pas de contradiction entre 03-01 et 03-02.
+VF_SCOPE="${VF_SCOPE:-project}"
 
-sync_cache() {
-  ensure_cache
-  log "Sync cache $CACHE_DIR..."
-  (cd "$CACHE_DIR" && git pull --depth 1 origin main 2>&1 | tail -3)
+# Détecter `--scope <val>` AVANT cmd="$1" : on filtre les positionnels et on override VF_SCOPE.
+_positional=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --scope)
+      [ "$#" -ge 2 ] || err "--scope nécessite une valeur (user|project|local)"
+      VF_SCOPE="$2"
+      shift 2
+      ;;
+    --scope=*)
+      VF_SCOPE="${1#--scope=}"
+      shift
+      ;;
+    *)
+      _positional+=("$1")
+      shift
+      ;;
+  esac
+done
+# Restaurer les positionnels nettoyés (set -u : guard tableau vide).
+if [ "${#_positional[@]}" -gt 0 ]; then
+  set -- "${_positional[@]}"
+else
+  set --
+fi
+
+# Validation stricte : rejette tôt toute valeur incohérente.
+case "$VF_SCOPE" in
+  user|project|local) : ;;
+  *) err "scope invalide : $VF_SCOPE (attendu user|project|local)" ;;
+esac
+
+# Résolution TARGET_ROOT depuis le scope.
+case "$VF_SCOPE" in
+  user)            TARGET_ROOT="$HOME/.claude" ;;
+  project|local)   TARGET_ROOT="./.claude" ;;
+esac
+export VF_SCOPE
+
+# ---------- Variables (toutes les cibles rebasées sur TARGET_ROOT) ----------
+CACHE_DIR="${VIBEFLOW_CACHE:-.vibeflow-cache}"   # SEULE source (plus de clone)
+INSTALLED_REGISTRY="$TARGET_ROOT/scripts/.vibeflow-installed"
+BACKUP_DIR="$TARGET_ROOT/.backups"
+
+# ---------- Cache (SCOPE-02 : plus de clone/pull, le cache doit exister) ----------
+require_cache() {
+  [ -d "$CACHE_DIR" ] || err "Cache introuvable : $CACHE_DIR (fournir VIBEFLOW_CACHE)"
 }
 
 list_available_modules() {
-  ensure_cache
+  require_cache
   for d in "$CACHE_DIR"/*/; do
     name=$(basename "$d")
     [ "$name" = "_internal" ] && continue
@@ -82,17 +130,93 @@ mark_uninstalled() {
   fi
 }
 
+# ---------- Résolveur de fermeture transitive (intégration Phase 2) ----------
+# Localise resolve-deps.sh : d'abord dans le cache (prod, bundlé par Phase 5/PLUG-02),
+# sinon à côté de l'engine (dev/source). Renvoie le chemin du résolveur, ou vide si absent.
+find_resolver() {
+  local candidate
+  candidate="$CACHE_DIR/_internal/resolve-deps.sh"
+  if [ -f "$candidate" ]; then echo "$candidate"; return 0; fi
+  candidate="$(dirname "$0")/resolve-deps.sh"
+  if [ -f "$candidate" ]; then echo "$candidate"; return 0; fi
+  echo ""
+}
+
+# resolve_closure <mod...> : émet sur stdout la fermeture transitive (1 module/ligne).
+# Si le résolveur est ABSENT, fallback best-effort = renvoie les args bruts, MAIS loue
+# un AVERTISSEMENT BRUYANT (warning visible) — closure incomplète = install possiblement cassée.
+resolve_closure() {
+  local resolver
+  resolver="$(find_resolver)"
+  if [ -z "$resolver" ]; then
+    # Fallback résolveur-absent : warning BRUYANT (sur stderr, sans exit) — T-03-08.
+    echo "[vibeflow-update] ERROR: ATTENTION : résolveur introuvable — fermeture transitive NON calculée. Les dépendances de $* ne seront PAS installées ; l'install peut être incomplète/cassée. (Phase 5/PLUG-02 doit bundler resolve-deps.sh dans le cache.)" >&2
+    printf '%s\n' "$@"
+    return 0
+  fi
+  # VF_MODULES_ROOT pointe sur le CACHE (les module.json y vivent), pas sur le repo.
+  VF_MODULES_ROOT="$CACHE_DIR" bash "$resolver" "$@"
+}
+
+# ---------- Gitignore local (SCOPE-04) ----------
+# Ajoute les chemins installés du module au ./.gitignore (cwd projet) UNIQUEMENT en scope local.
+# Idempotent : pas de doublon (grep -qxF avant ajout). Crée .gitignore s'il manque.
+gitignore_add_one() {
+  local path="$1"
+  # Création paresseuse du .gitignore au premier ajout.
+  [ -f .gitignore ] || : > .gitignore
+  if ! grep -qxF "$path" .gitignore; then
+    echo "$path" >> .gitignore
+    log "  gitignore += $path"
+  fi
+}
+
+gitignore_add_paths() {
+  local mod="$1"
+  # Scope local seulement : user/project ne touchent JAMAIS au .gitignore.
+  [ "$VF_SCOPE" = "local" ] || return 0
+
+  local module_dir="$CACHE_DIR/$mod"
+
+  # Skill racine.
+  [ -f "$module_dir/SKILL.md" ] && gitignore_add_one ".claude/skills/$mod/"
+  # Skills imbriqués.
+  if [ -d "$module_dir/skills" ]; then
+    for skill_dir in "$module_dir/skills/"*/; do
+      [ -d "$skill_dir" ] || continue
+      gitignore_add_one ".claude/skills/$(basename "$skill_dir")/"
+    done
+  fi
+  # Agent module (D7) : AGENT.md + dossier references.
+  if [ -f "$module_dir/AGENT.md" ]; then
+    gitignore_add_one ".claude/agents/${mod}.md"
+    [ -d "$module_dir/references" ] && gitignore_add_one ".claude/agents/${mod}-references/"
+  fi
+  # Rules réellement posées.
+  if [ -d "$module_dir/rules" ]; then
+    for f in "$module_dir/rules/"*.md; do
+      [ -f "$f" ] && gitignore_add_one ".claude/rules/$(basename "$f")"
+    done
+  fi
+  # Scripts réellement posés.
+  if [ -d "$module_dir/scripts" ]; then
+    for f in "$module_dir/scripts/"*.sh; do
+      [ -f "$f" ] && gitignore_add_one ".claude/scripts/$(basename "$f")"
+    done
+  fi
+}
+
 # ---------- Install ----------
 install_module() {
   local mod="$1"
-  ensure_cache
+  require_cache
 
   local module_dir="$CACHE_DIR/$mod"
   [ -d "$module_dir" ] || err "Module $mod introuvable dans $CACHE_DIR"
 
   local version
   version=$(module_version_available "$mod")
-  log "Installation $mod $version..."
+  log "Installation $mod $version (scope=$VF_SCOPE → $TARGET_ROOT)..."
 
   # Backup if existing install
   local installed
@@ -104,9 +228,9 @@ install_module() {
 
   # Type 1 — Single-skill module : SKILL.md at module root
   if [ -f "$module_dir/SKILL.md" ]; then
-    mkdir -p ".claude/skills/$mod"
-    cp "$module_dir/SKILL.md" ".claude/skills/$mod/SKILL.md"
-    log "  copied SKILL.md → .claude/skills/$mod/"
+    mkdir -p "$TARGET_ROOT/skills/$mod"
+    cp "$module_dir/SKILL.md" "$TARGET_ROOT/skills/$mod/SKILL.md"
+    log "  copied SKILL.md → $TARGET_ROOT/skills/$mod/"
   fi
 
   # Type 2 — Multi-skills module : skills/<name>/SKILL.md (e.g., skill-creator with 2 nested skills)
@@ -114,75 +238,80 @@ install_module() {
     for skill_dir in "$module_dir/skills/"*/; do
       [ -d "$skill_dir" ] || continue
       skill_name=$(basename "$skill_dir")
-      mkdir -p ".claude/skills/$skill_name"
-      cp -r "$skill_dir"* ".claude/skills/$skill_name/" 2>/dev/null || true
-      log "  copied nested skill → .claude/skills/$skill_name/"
+      mkdir -p "$TARGET_ROOT/skills/$skill_name"
+      cp -r "$skill_dir"* "$TARGET_ROOT/skills/$skill_name/" 2>/dev/null || true
+      log "  copied nested skill → $TARGET_ROOT/skills/$skill_name/"
     done
   fi
 
-  # Type 3 — Agent module : AGENT.md → .claude/agents/<mod>.md
+  # Type 3 — Agent module : AGENT.md → $TARGET_ROOT/agents/<mod>.md
   if [ -f "$module_dir/AGENT.md" ]; then
-    mkdir -p ".claude/agents"
-    cp "$module_dir/AGENT.md" ".claude/agents/${mod}.md"
-    log "  copied AGENT.md → .claude/agents/${mod}.md"
+    mkdir -p "$TARGET_ROOT/agents"
+    cp "$module_dir/AGENT.md" "$TARGET_ROOT/agents/${mod}.md"
+    log "  copied AGENT.md → $TARGET_ROOT/agents/${mod}.md"
   fi
 
   # Type 4 — Doc-only module : content/ → docs/<mod>/
+  # EXCEPTION scope : la doc reste relative au cwd PROJET (ce n'est pas du .claude),
+  # donc PAS rebasée sur TARGET_ROOT même en scope user.
   if [ -d "$module_dir/content" ]; then
     local doc_target="docs/$mod"
     mkdir -p "$doc_target"
     cp -r "$module_dir/content/"* "$doc_target/" 2>/dev/null || true
-    log "  copied content/ → $doc_target/ (doc module)"
+    log "  copied content/ → $doc_target/ (doc module, hors TARGET_ROOT)"
   fi
 
-  # Type 5 — Rules : rules/*.md → .claude/rules/ (rules path-scopées auto-chargées par Claude Code)
+  # Type 5 — Rules : rules/*.md → $TARGET_ROOT/rules/ (rules path-scopées auto-chargées)
   if [ -d "$module_dir/rules" ]; then
-    mkdir -p ".claude/rules"
-    cp "$module_dir/rules/"*.md ".claude/rules/" 2>/dev/null || true
-    log "  copied rules/ → .claude/rules/"
+    mkdir -p "$TARGET_ROOT/rules"
+    cp "$module_dir/rules/"*.md "$TARGET_ROOT/rules/" 2>/dev/null || true
+    log "  copied rules/ → $TARGET_ROOT/rules/"
   fi
 
   # References folder at module root (companion to root SKILL.md)
   if [ -d "$module_dir/references" ] && [ -f "$module_dir/SKILL.md" ]; then
-    mkdir -p ".claude/skills/$mod/references"
-    cp -r "$module_dir/references/"* ".claude/skills/$mod/references/" 2>/dev/null || true
-    log "  copied references/ → .claude/skills/$mod/references/"
+    mkdir -p "$TARGET_ROOT/skills/$mod/references"
+    cp -r "$module_dir/references/"* "$TARGET_ROOT/skills/$mod/references/" 2>/dev/null || true
+    log "  copied references/ → $TARGET_ROOT/skills/$mod/references/"
   fi
 
   # References folder for AGENT modules (D7) : un module agent (AGENT.md sans SKILL.md racine)
-  # embarque ses references sous .claude/agents/<mod>-references/ (chargées on-demand par l'agent).
+  # embarque ses references sous $TARGET_ROOT/agents/<mod>-references/ (chargées on-demand).
   if [ -d "$module_dir/references" ] && [ -f "$module_dir/AGENT.md" ]; then
-    mkdir -p ".claude/agents/${mod}-references"
-    cp -r "$module_dir/references/"* ".claude/agents/${mod}-references/" 2>/dev/null || true
-    log "  copied references/ → .claude/agents/${mod}-references/"
+    mkdir -p "$TARGET_ROOT/agents/${mod}-references"
+    cp -r "$module_dir/references/"* "$TARGET_ROOT/agents/${mod}-references/" 2>/dev/null || true
+    log "  copied references/ → $TARGET_ROOT/agents/${mod}-references/"
   fi
 
   # Scripts (top-level + tests subdir)
   if [ -d "$module_dir/scripts" ]; then
-    mkdir -p ".claude/scripts"
+    mkdir -p "$TARGET_ROOT/scripts"
     for f in "$module_dir/scripts/"*.sh; do
-      [ -f "$f" ] && cp "$f" ".claude/scripts/" && chmod +x ".claude/scripts/$(basename "$f")"
+      [ -f "$f" ] && cp "$f" "$TARGET_ROOT/scripts/" && chmod +x "$TARGET_ROOT/scripts/$(basename "$f")"
     done
     if [ -d "$module_dir/scripts/tests" ]; then
-      mkdir -p ".claude/scripts/tests/fixtures"
-      cp -r "$module_dir/scripts/tests/"*.sh ".claude/scripts/tests/" 2>/dev/null || true
-      cp -r "$module_dir/scripts/tests/fixtures/"* ".claude/scripts/tests/fixtures/" 2>/dev/null || true
-      chmod +x .claude/scripts/tests/*.sh 2>/dev/null || true
+      mkdir -p "$TARGET_ROOT/scripts/tests/fixtures"
+      cp -r "$module_dir/scripts/tests/"*.sh "$TARGET_ROOT/scripts/tests/" 2>/dev/null || true
+      cp -r "$module_dir/scripts/tests/fixtures/"* "$TARGET_ROOT/scripts/tests/fixtures/" 2>/dev/null || true
+      chmod +x "$TARGET_ROOT"/scripts/tests/*.sh 2>/dev/null || true
     fi
-    log "  copied scripts/ → .claude/scripts/"
+    log "  copied scripts/ → $TARGET_ROOT/scripts/"
   fi
 
   # Hook post-install (IDX-02 / D7) : si le module fournit build-gsd-index.sh, régénérer
   # l'index factuel in-place dans le dossier references agent. Best-effort : ne JAMAIS
   # faire échouer l'install si GSD est absent (l'index sera régénéré plus tard).
-  if [ -f "$module_dir/scripts/build-gsd-index.sh" ] && [ -f ".claude/scripts/build-gsd-index.sh" ]; then
-    if VF_INDEX_OUT=".claude/agents/${mod}-references/gsd-skills-index.md" \
-       bash ".claude/scripts/build-gsd-index.sh" >/dev/null 2>&1; then
-      log "  index régénéré → .claude/agents/${mod}-references/gsd-skills-index.md"
+  if [ -f "$module_dir/scripts/build-gsd-index.sh" ] && [ -f "$TARGET_ROOT/scripts/build-gsd-index.sh" ]; then
+    if VF_INDEX_OUT="$TARGET_ROOT/agents/${mod}-references/gsd-skills-index.md" \
+       bash "$TARGET_ROOT/scripts/build-gsd-index.sh" >/dev/null 2>&1; then
+      log "  index régénéré → $TARGET_ROOT/agents/${mod}-references/gsd-skills-index.md"
     else
       log "  (index non régénéré — GSD absent, best-effort)"
     fi
   fi
+
+  # SCOPE-04 : en scope local seulement, ajouter les chemins installés au ./.gitignore.
+  gitignore_add_paths "$mod"
 
   mark_installed "$mod" "$version"
   log "✓ $mod $version installé"
@@ -195,16 +324,16 @@ backup_module() {
   ts=$(date +%Y%m%d-%H%M%S)
   local bdir="$BACKUP_DIR/$mod-$ts"
   mkdir -p "$bdir"
-  [ -d ".claude/skills/$mod" ] && cp -r ".claude/skills/$mod" "$bdir/skills"
+  [ -d "$TARGET_ROOT/skills/$mod" ] && cp -r "$TARGET_ROOT/skills/$mod" "$bdir/skills"
   # Agent module : AGENT.md installé + son dossier references (D7)
-  [ -f ".claude/agents/${mod}.md" ] && { mkdir -p "$bdir/agents"; cp ".claude/agents/${mod}.md" "$bdir/agents/"; }
-  [ -d ".claude/agents/${mod}-references" ] && cp -r ".claude/agents/${mod}-references" "$bdir/agent-references"
+  [ -f "$TARGET_ROOT/agents/${mod}.md" ] && { mkdir -p "$bdir/agents"; cp "$TARGET_ROOT/agents/${mod}.md" "$bdir/agents/"; }
+  [ -d "$TARGET_ROOT/agents/${mod}-references" ] && cp -r "$TARGET_ROOT/agents/${mod}-references" "$bdir/agent-references"
   # Scripts (les scripts du module sont mélangés avec les autres — backup uniquement les nommés dans le module)
   if [ -d "$CACHE_DIR/$mod/scripts" ]; then
     mkdir -p "$bdir/scripts"
     for f in "$CACHE_DIR/$mod/scripts/"*.sh; do
       name=$(basename "$f")
-      [ -f ".claude/scripts/$name" ] && cp ".claude/scripts/$name" "$bdir/scripts/"
+      [ -f "$TARGET_ROOT/scripts/$name" ] && cp "$TARGET_ROOT/scripts/$name" "$bdir/scripts/"
     done
   fi
   log "  backup → $bdir"
@@ -219,13 +348,13 @@ rollback_module() {
 
   log "Rollback $mod depuis $latest..."
   if [ -d "$latest/skills" ]; then
-    rm -rf ".claude/skills/$mod"
-    cp -r "$latest/skills" ".claude/skills/$mod"
-    log "  restored .claude/skills/$mod"
+    rm -rf "$TARGET_ROOT/skills/$mod"
+    cp -r "$latest/skills" "$TARGET_ROOT/skills/$mod"
+    log "  restored $TARGET_ROOT/skills/$mod"
   fi
   if [ -d "$latest/scripts" ]; then
     for f in "$latest/scripts/"*; do
-      [ -f "$f" ] && cp "$f" ".claude/scripts/" && chmod +x ".claude/scripts/$(basename "$f")"
+      [ -f "$f" ] && cp "$f" "$TARGET_ROOT/scripts/" && chmod +x "$TARGET_ROOT/scripts/$(basename "$f")"
     done
     log "  restored scripts"
   fi
@@ -235,30 +364,30 @@ rollback_module() {
 # ---------- Uninstall ----------
 uninstall_module() {
   local mod="$1"
-  log "Désinstallation $mod..."
+  log "Désinstallation $mod (scope=$VF_SCOPE → $TARGET_ROOT)..."
   backup_module "$mod"
 
   # Remove skill dir
-  if [ -d ".claude/skills/$mod" ]; then
-    rm -rf ".claude/skills/$mod"
-    log "  removed .claude/skills/$mod"
+  if [ -d "$TARGET_ROOT/skills/$mod" ]; then
+    rm -rf "$TARGET_ROOT/skills/$mod"
+    log "  removed $TARGET_ROOT/skills/$mod"
   fi
 
   # Remove agent module (AGENT.md installé + dossier references D7)
-  if [ -f ".claude/agents/${mod}.md" ]; then
-    rm -f ".claude/agents/${mod}.md"
-    log "  removed .claude/agents/${mod}.md"
+  if [ -f "$TARGET_ROOT/agents/${mod}.md" ]; then
+    rm -f "$TARGET_ROOT/agents/${mod}.md"
+    log "  removed $TARGET_ROOT/agents/${mod}.md"
   fi
-  if [ -d ".claude/agents/${mod}-references" ]; then
-    rm -rf ".claude/agents/${mod}-references"
-    log "  removed .claude/agents/${mod}-references"
+  if [ -d "$TARGET_ROOT/agents/${mod}-references" ]; then
+    rm -rf "$TARGET_ROOT/agents/${mod}-references"
+    log "  removed $TARGET_ROOT/agents/${mod}-references"
   fi
 
   # Remove scripts (only those owned by this module)
   if [ -d "$CACHE_DIR/$mod/scripts" ]; then
     for f in "$CACHE_DIR/$mod/scripts/"*.sh; do
       name=$(basename "$f")
-      [ -f ".claude/scripts/$name" ] && rm ".claude/scripts/$name" && log "  removed .claude/scripts/$name"
+      [ -f "$TARGET_ROOT/scripts/$name" ] && rm "$TARGET_ROOT/scripts/$name" && log "  removed $TARGET_ROOT/scripts/$name"
     done
   fi
 
@@ -266,7 +395,7 @@ uninstall_module() {
   if [ -d "$CACHE_DIR/$mod/rules" ]; then
     for f in "$CACHE_DIR/$mod/rules/"*.md; do
       name=$(basename "$f")
-      [ -f ".claude/rules/$name" ] && rm ".claude/rules/$name" && log "  removed .claude/rules/$name"
+      [ -f "$TARGET_ROOT/rules/$name" ] && rm "$TARGET_ROOT/rules/$name" && log "  removed $TARGET_ROOT/rules/$name"
     done
   fi
 
@@ -276,7 +405,7 @@ uninstall_module() {
 
 # ---------- Status ----------
 show_status() {
-  ensure_cache
+  require_cache
   printf "%-30s %-15s %-15s %s\n" "Module" "Installed" "Available" "Status"
   printf "%-30s %-15s %-15s %s\n" "------" "---------" "---------" "------"
   for mod in $(list_available_modules); do
@@ -296,7 +425,7 @@ show_status() {
 # ---------- Update ----------
 update_module() {
   local mod="$1"
-  sync_cache
+  require_cache
   local installed available
   installed=$(module_version_installed "$mod")
   available=$(module_version_available "$mod")
@@ -327,17 +456,25 @@ arg="${2:-}"
 case "$cmd" in
   install)
     if [ "$arg" = "--all" ]; then
-      ensure_cache
+      require_cache
       for m in $(list_available_modules); do install_module "$m"; done
+    elif [ "$arg" = "--with-deps" ]; then
+      # install --with-deps <mod> : installe la fermeture transitive (résolveur câblé).
+      deps_target="${3:-}"
+      [ -n "$deps_target" ] || err "Usage: install --with-deps <module>"
+      require_cache
+      while IFS= read -r m; do
+        [ -n "$m" ] && install_module "$m"
+      done < <(resolve_closure "$deps_target")
     elif [ -n "$arg" ]; then
       install_module "$arg"
     else
-      err "Usage: install <module> | install --all"
+      err "Usage: install <module> | install --with-deps <module> | install --all"
     fi
     ;;
   update)
     if [ "$arg" = "--all" ]; then
-      sync_cache
+      require_cache
       if [ -f "$INSTALLED_REGISTRY" ]; then
         while IFS='=' read -r mod ver; do
           [ -n "$mod" ] && update_module "$mod"
@@ -363,7 +500,8 @@ case "$cmd" in
     show_status
     ;;
   sync)
-    sync_cache
+    # No-op explicite (SCOPE-02) : la source est le cache fourni, plus de sync git.
+    log "source = cache fourni (VIBEFLOW_CACHE=$CACHE_DIR), plus de sync git"
     ;;
   *)
     grep '^# ' "$0" | sed 's/^# //'

--- a/audit-architecture/module.json
+++ b/audit-architecture/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-architecture",
+  "version": "v1.0.0",
+  "type": "single-skill+references",
+  "description": "Audit d'architecture logicielle d'un codebase.",
+  "requires": []
+}

--- a/consolidator/module.json
+++ b/consolidator/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "consolidator",
+  "version": "v1.0.0",
+  "type": "single-skill+scripts",
+  "description": "Consolidation de la mémoire projet sur 4 piliers.",
+  "requires": []
+}

--- a/dev-orchestrator/AGENT.md
+++ b/dev-orchestrator/AGENT.md
@@ -29,6 +29,21 @@ memory: project
 
 ---
 
+## Garde-fou premier usage (first-use)
+
+**Avant de router toute intention de dev structurante** (« code », « planifie », « teste »,
+« débugge »… — les verbes qui supposent un projet cadré), je vérifie que le projet est initialisé.
+
+1. **Détection (FIRST-01)** : critère = présence de `.planning/PROJECT.md` (ou du dossier
+   `.planning/`). Commande : `test -f .planning/PROJECT.md`. Si ABSENT → projet non initialisé
+   → je ne route PAS le verbe de dev tout de suite.
+2. **Proposition (FIRST-02)** : dans ce cas je bascule sur le skill `vf-init`, qui PROPOSE la
+   cartographie du code existant (si du code existe) puis le démarrage de projet sur confirmation
+   EXPLICITE. Je délègue la séquence à `vf-init` (pas de réécriture ici) et je ne lance JAMAIS
+   `gsd-new-project` seul ni en autonomie (cohérent BOOT-04 / Iron Law 4).
+
+---
+
 ## Table de routage (langage naturel → action coulisse)
 
 Je détecte l'intention sous une grande variété de formulations (couverture maximale), puis je délègue.
@@ -94,6 +109,8 @@ d'orchestration non triviale se présente.
 - **Action structurante** : clarifier (P4) **avant**, vérifier (P5) **après**.
 - **`gsd-new-project` est interactif** : je ne le lance **jamais** seul ni en autonomie.
   Je le **propose** uniquement après confirmation explicite (« je veux démarrer un projet »).
+- **Premier usage** : projet non initialisé (`.planning/PROJECT.md` absent) → je bascule sur
+  `vf-init` (proposition d'init) **avant** de router un verbe de dev, jamais l'inverse.
 - **Aucune fuite de plomberie** : zéro « GSD », « Superpowers » ou nom de skill brut côté
   utilisateur. Toujours reformuler en vocabulaire VibeFlow.
 
@@ -114,6 +131,7 @@ d'orchestration non triviale se présente.
 - ❌ Coder une feature à la main alors qu'un skill outillé existe.
 - ❌ Planifier sans cadrage préalable sur une demande floue.
 - ❌ Lancer `gsd-new-project` automatiquement.
+- ❌ Router une intention de dev sur un projet non initialisé sans proposer l'init (`vf-init`).
 - ❌ Sauter la recette / la revue sur une feature structurante.
 
 ---

--- a/dev-orchestrator/module.json
+++ b/dev-orchestrator/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "dev-orchestrator",
+  "version": "v1.1.0",
+  "type": "agent+skills",
+  "description": "Orchestrateur de développement : route le langage naturel vers le pipeline.",
+  "requires": []
+}

--- a/dev-orchestrator/scripts/ensure-deps.sh
+++ b/dev-orchestrator/scripts/ensure-deps.sh
@@ -2,8 +2,8 @@
 # ensure-deps.sh — Bootstrap auto-install non-interactif des dépendances (dev-orchestrator)
 #
 # Vision §1 / D3 : rendre les deux dépendances invisibles et auto-installées.
-#   - GSD          → via npm (npx get-shit-done-cc), flags --claude + --global (non-interactif).
-#   - Superpowers  → via plugin Claude Code (claude plugin install --scope user).
+#   - GSD          → via npm (npx get-shit-done-cc), flag --claude + flag de scope dérivé (non-interactif).
+#   - Superpowers  → via plugin Claude Code (claude plugin install --scope <scope>).
 #
 # Garde-fou (D3 / BOOT-04) : ce script NE LANCE JAMAIS `gsd-new-project` (interactif).
 # L'init projet reste sur confirmation explicite de l'agent.
@@ -12,16 +12,31 @@
 #   ./ensure-deps.sh                       # détecte + auto-installe ce qui manque
 #   VF_ENSURE_DRY_RUN=1 ./ensure-deps.sh   # détecte + logue les commandes SANS les exécuter (tests, idempotence)
 #   VF_ENSURE_AUTO_MAP=1 ./ensure-deps.sh  # autorise un message map-codebase si du code est détecté (non-interactif)
+#   VF_SCOPE=project ./ensure-deps.sh      # scope d'install (user|project|local) — voir mapping ci-dessous
+#   VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 ./ensure-deps.sh  # dry-run observable : logue la cmd scopée même si déps présentes
 #
 # Variables d'environnement :
 #   VF_ENSURE_DRY_RUN  (défaut vide) — 1 → simule sans exécuter npx/claude.
 #   VF_ENSURE_AUTO_MAP (défaut vide) — 1 → logue que gsd-map-codebase est lançable si codebase détecté.
+#   VF_SCOPE           (défaut user) — scope d'install : user|project|local. Mapping (spec §3 / §8) :
+#                        GSD :         user → --global ; project|local → --local
+#                        Superpowers : user|project|local → --scope <même valeur>
+#                      Le défaut LEGACY `user` est un fallback pour les APPELS DIRECTS uniquement
+#                      (CI, debug, run manuel). EN PRODUCTION, le skill /vibeflow-install (Phase 4)
+#                      passe TOUJOURS un VF_SCOPE explicite à l'engine ET à ce script (un seul scope
+#                      partout — cohérence ID4, spec §3/§8). Ce défaut ne co-occurre donc jamais en prod
+#                      avec le défaut LEGACY de l'engine (`project`). Une valeur explicite incohérente
+#                      est rejetée tôt par la validation stricte ci-dessous (err + exit 1).
+#   VF_ENSURE_FORCE    (défaut vide) — 1 → EN DRY-RUN UNIQUEMENT, court-circuite l'early-return de
+#                      détection (skip) pour loguer la commande scopée QUI SERAIT émise, sans rien
+#                      installer. Sans effet hors dry-run (jamais d'install forcée). Rend le dry-run
+#                      observable sur une machine où GSD/Superpowers sont déjà présents (CI/dev).
 #
-# Comportement : idempotent (2e run consécutif = no-op). Jamais d'échec silencieux :
+# Comportement : idempotent (2e run consécutif = no-op, mode normal non forcé). Jamais d'échec silencieux :
 # si un prérequis (Node/npm ou CLI claude) manque, les étapes manuelles sont affichées et exit 0.
 #
 # Référence : BOOT-01 (GSD auto), BOOT-02 (Superpowers auto), BOOT-03 (idempotent + fallback manuel),
-#             BOOT-04 (gsd-new-project jamais lancé seul), D3.
+#             BOOT-04 (gsd-new-project jamais lancé seul), SCOPE-03 (scope-aware via VF_SCOPE), D3.
 
 # Pas de `-e` : certaines détections (command -v, grep) doivent pouvoir échouer sans tuer le script.
 set -uo pipefail
@@ -29,6 +44,12 @@ set -uo pipefail
 # ---------- Variables ----------
 DRY_RUN="${VF_ENSURE_DRY_RUN:-}"
 AUTO_MAP="${VF_ENSURE_AUTO_MAP:-}"
+# Scope d'install. Défaut LEGACY `user` = rétro-compat APPEL-DIRECT (le skill /vibeflow-install
+# de Phase 4 passe TOUJOURS un VF_SCOPE explicite en prod — cohérence ID4, voir en-tête).
+SCOPE="${VF_SCOPE:-user}"
+# 1 → en DRY-RUN, court-circuite l'early-return de détection pour loguer la cmd scopée (sans installer).
+# Sans effet hors dry-run (jamais d'install forcée).
+FORCE="${VF_ENSURE_FORCE:-}"
 GSD_VERSION_FILE="$HOME/.claude/get-shit-done/VERSION"
 PLUGINS_CACHE_DIR="$HOME/.claude/plugins/cache"
 
@@ -40,6 +61,27 @@ log() {
 err() {
   echo "[ensure-deps] ERROR: $*" >&2
 }
+
+# ---------- Validation du scope (T-03-04) ----------
+# Valider VF_SCOPE EN TÊTE, AVANT toute définition de main et tout effet de bord / run_cmd :
+# un scope invalide injecté dans les flags d'install est rejeté tôt (err + exit 1).
+case "$SCOPE" in
+  user | project | local) ;;
+  *)
+    err "VF_SCOPE invalide : $SCOPE (attendu user|project|local)"
+    exit 1
+    ;;
+esac
+
+# Dérivation des flags de scope (spec §3 / §8) :
+#   GSD :         user → --global ; project|local → --local
+#   Superpowers : user|project|local → --scope <même valeur>
+if [ "$SCOPE" = "user" ]; then
+  GSD_SCOPE_FLAG="--global"
+else
+  GSD_SCOPE_FLAG="--local"
+fi
+SUPERPOWERS_SCOPE="$SCOPE"
 
 # Exécute une commande, ou la logue seulement en mode dry-run. Retourne le code de sortie réel.
 run_cmd() {
@@ -58,7 +100,9 @@ detect_gsd() {
 }
 
 ensure_gsd() {
-  if detect_gsd; then
+  # Early-return skip si GSD détecté — SAUF en dry-run forcé (on tombe alors dans le chemin run_cmd
+  # qui ne fait que loguer la cmd scopée, sans installer). Mode normal : comportement inchangé.
+  if detect_gsd && ! { [ -n "$DRY_RUN" ] && [ -n "$FORCE" ]; }; then
     log "GSD déjà présent (skip)."
     return 0
   fi
@@ -72,8 +116,8 @@ ensure_gsd() {
     return 0
   fi
 
-  log "GSD absent — installation via npx (non-interactif)..."
-  if run_cmd npx -y get-shit-done-cc@latest --claude --global; then
+  log "GSD absent — installation via npx (non-interactif, scope=$SCOPE → $GSD_SCOPE_FLAG)..."
+  if run_cmd npx -y get-shit-done-cc@latest --claude "$GSD_SCOPE_FLAG"; then
     log "GSD installé via npx."
     return 0
   fi
@@ -81,7 +125,7 @@ ensure_gsd() {
   # Échec de l'install → bascule sur étapes manuelles (pas d'échec silencieux).
   err "L'auto-install GSD a échoué."
   log "Étape manuelle GSD :"
-  log "  npx -y get-shit-done-cc@latest --claude --global"
+  log "  npx -y get-shit-done-cc@latest --claude $GSD_SCOPE_FLAG"
   return 0
 }
 
@@ -96,7 +140,9 @@ detect_superpowers() {
 }
 
 ensure_superpowers() {
-  if detect_superpowers; then
+  # Early-return skip si Superpowers détecté — SAUF en dry-run forcé (on logue alors la cmd scopée
+  # via run_cmd sans installer). Mode normal : comportement inchangé.
+  if detect_superpowers && ! { [ -n "$DRY_RUN" ] && [ -n "$FORCE" ]; }; then
     log "Superpowers déjà présent (skip)."
     return 0
   fi
@@ -109,8 +155,8 @@ ensure_superpowers() {
     return 0
   fi
 
-  log "Superpowers absent — installation via plugin (non-interactif)..."
-  if run_cmd claude plugin install superpowers@claude-plugins-official --scope user; then
+  log "Superpowers absent — installation via plugin (non-interactif, --scope $SUPERPOWERS_SCOPE)..."
+  if run_cmd claude plugin install superpowers@claude-plugins-official --scope "$SUPERPOWERS_SCOPE"; then
     log "Superpowers installé via plugin."
     return 0
   fi
@@ -118,14 +164,15 @@ ensure_superpowers() {
   # Fallback : ajouter le marketplace puis re-tenter l'install.
   log "Install directe KO — tentative via marketplace..."
   if run_cmd claude plugin marketplace add anthropics/claude-plugins-official &&
-    run_cmd claude plugin install superpowers@claude-plugins-official --scope user; then
+    run_cmd claude plugin install superpowers@claude-plugins-official --scope "$SUPERPOWERS_SCOPE"; then
     log "Superpowers installé via marketplace + plugin."
     return 0
   fi
 
   # Toujours KO → étape manuelle (jamais d'échec silencieux).
+  # La TUI Claude Code n'expose pas de flag de scope : on indique le scope visé en commentaire.
   err "L'auto-install Superpowers a échoué (directe + marketplace)."
-  log "Étape manuelle Superpowers (dans la TUI Claude Code) :"
+  log "Étape manuelle Superpowers (dans la TUI Claude Code, scope visé : $SUPERPOWERS_SCOPE) :"
   log "  /plugin install superpowers@claude-plugins-official"
   return 0
 }

--- a/dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
+++ b/dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
@@ -13,6 +13,8 @@
 #   T5 — Densité (VERIF-02) MESURÉE PAR wc -l UNIQUEMENT : AGENT.md ≤250L, chaque skill ≤500L.
 #        (NE PAS appeler le contrôleur de taille générique qui ignore les .md.)
 #   T6 — Install end-to-end via vibeflow-update.sh (best-effort, SKIP si non réalisable).
+#   T7 — Garde-fou first-use présent dans AGENT.md : détection .planning + délégation vf-init
+#        + new-project encadré (régression FIRST-01/FIRST-02 ; fichier filtré des commentaires).
 #
 # Convention : asserts numérotés, helpers ok()/ko()/skip(), exit 0 si tout passe
 # (SKIP non bloquant), exit 1 si au moins un KO. Calqué sur le pattern de test du repo.
@@ -267,6 +269,22 @@ else
     skip "T6 install e2e : install non réalisable dans l'environnement (best-effort)"
   fi
   rm -rf "$LAB"
+fi
+
+# ---------------------------------------------------------------------------
+# T7 — Garde-fou first-use présent dans AGENT.md (régression FIRST-01/FIRST-02)
+# ---------------------------------------------------------------------------
+# Présence du garde-fou sur fichier FILTRÉ des commentaires (hygiène grep-gate : un simple
+# commentaire ne doit pas suffire). Pas de check densité ici (T5 le fait déjà via wc -l).
+has_marker=$("$GREP" -v '^#' "$AGENT_FILE" | "$GREP" -ci 'first-use\|premier usage')
+has_detect=0; "$GREP" -q -- '.planning' "$AGENT_FILE" && has_detect=1
+has_vfinit=0; "$GREP" -q -- 'vf-init'   "$AGENT_FILE" && has_vfinit=1
+has_noauto=$("$GREP" -v '^#' "$AGENT_FILE" | "$GREP" -ci 'new-project')
+
+if [ "${has_marker:-0}" -ge 1 ] && [ "$has_detect" -eq 1 ] && [ "$has_vfinit" -eq 1 ] && [ "${has_noauto:-0}" -ge 1 ]; then
+  ok "T7 first-use : garde-fou présent (détection .planning + délégation vf-init + new-project encadré)"
+else
+  ko "T7 first-use : garde-fou incomplet dans AGENT.md (marker=$has_marker detect=$has_detect vfinit=$has_vfinit noauto=$has_noauto)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
+++ b/dev-orchestrator/scripts/tests/test-dev-orchestrator.sh
@@ -90,6 +90,51 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# T2b — ensure-deps scopé (dry-run FORCÉ, sans réseau) — SCOPE-03
+# ---------------------------------------------------------------------------
+# VF_ENSURE_FORCE=1 (en plus de VF_ENSURE_DRY_RUN=1) court-circuite l'early-return de détection :
+# les commandes scopées sont donc LOGUÉES même si GSD/Superpowers sont déjà installés sur la machine
+# (cas dev/CI courant — sans FORCE, l'early-return skip masquerait les flags → faux-négatif).
+# FORCE ne fait que loguer via run_cmd : AUCUN appel réseau ni install (dry-run uniquement).
+ENS="$MOD/scripts/ensure-deps.sh"
+t2b_fail=0
+
+# (user|project|local) → flags GSD + Superpowers attendus.
+# user → --global / --scope user ; project → --local / --scope project ; local → --local / --scope local.
+assert_scope() {
+  local scope="$1" gsd_flag="$2" sp_flag="$3" out
+  out=$(VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 VF_SCOPE="$scope" bash "$ENS" 2>&1)
+  if echo "$out" | "$GREP" -q -- "$gsd_flag" && echo "$out" | "$GREP" -q -- "$sp_flag"; then
+    ok "T2b scope=$scope : GSD $gsd_flag + Superpowers $sp_flag logués (dry-run forcé)"
+  else
+    ko "T2b scope=$scope : flags attendus absents ($gsd_flag / $sp_flag)"
+    t2b_fail=$((t2b_fail+1))
+  fi
+}
+
+assert_scope user    "--global" "--scope user"
+assert_scope project "--local"  "--scope project"
+assert_scope local   "--local"  "--scope local"
+
+# Rétro-compat : sans VF_SCOPE (dry-run forcé) → défaut LEGACY user (--global / --scope user).
+out_default=$(VF_ENSURE_DRY_RUN=1 VF_ENSURE_FORCE=1 bash "$ENS" 2>&1)
+if echo "$out_default" | "$GREP" -q -- "--global" && echo "$out_default" | "$GREP" -q -- "--scope user"; then
+  ok "T2b rétro-compat : sans VF_SCOPE → --global + --scope user (défaut LEGACY)"
+else
+  ko "T2b rétro-compat : défaut LEGACY user attendu (--global / --scope user)"
+  t2b_fail=$((t2b_fail+1))
+fi
+
+# Validation : scope invalide rejeté AVANT effet de bord (exit≠0). Pas besoin de FORCE (validation en tête).
+VF_ENSURE_DRY_RUN=1 VF_SCOPE=bogus bash "$ENS" >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+  ok "T2b validation : VF_SCOPE=bogus rejeté (exit≠0 avant effet de bord)"
+else
+  ko "T2b validation : VF_SCOPE=bogus aurait dû être rejeté (exit≠0)"
+  t2b_fail=$((t2b_fail+1))
+fi
+
+# ---------------------------------------------------------------------------
 # T3 — Routage AGENT.md : ≥11 cibles DISTINCTES ET ≥11 lignes d'intentions NL
 # ---------------------------------------------------------------------------
 AGENT="$AGENT_FILE"

--- a/docs/superpowers/specs/2026-06-04-install-ux-design.md
+++ b/docs/superpowers/specs/2026-06-04-install-ux-design.md
@@ -7,17 +7,19 @@
 ## 1. Vision
 
 Réduire l'installation de VibeFlow et de ses modules à **presque aucune étape technique**.
-Cible :
+Cible — **deux commandes**, puis l'UX se lance toute seule :
 
 ```
 claude plugin marketplace add picmakpro/vibeflow-os
 claude plugin install vibeflow
-/vibeflow-install
+# → au prochain démarrage de session, l'UX à toggles s'ouvre automatiquement
 ```
 
-Le skill `/vibeflow-install` présente deux listes de toggles dans le terminal — **scope**
-(user/project/local) puis **modules** — et installe tout au bon endroit, dépendances
-auto-résolues. Aucun clone, aucun script à lancer à la main, aucune édition de `settings.json`.
+À la **première session** après l'install, un hook `SessionStart` du plugin détecte le premier
+lancement et **lance automatiquement** l'UX interactive (deux listes de toggles : **scope**
+user/project/local, puis **modules**), installe tout au bon endroit, dépendances auto-résolues.
+Aucun `/vibeflow-install` à taper, aucun clone, aucun script à lancer, aucune édition de `settings.json`.
+Le skill `/vibeflow-install` reste invocable manuellement pour re-configurer plus tard.
 
 **Objectif mesurable** : depuis zéro, un utilisateur installe le plugin et obtient les modules
 voulus au scope voulu (+ GSD + Superpowers) sans jamais taper de commande shell d'installation
@@ -32,6 +34,7 @@ ni cloner de repo.
 | ID3 | Packaging | Le plugin **bundle tout** (modules + skill + engine + manifeste) ; le skill copie depuis le cache plugin → scope ; **pas de git clone** |
 | ID4 | Scope | **Un seul** choix (user/project/local) appliqué à tout : modules VibeFlow + GSD + Superpowers |
 | ID5 | UX interactive | Skill `/vibeflow-install` ; les "toggles" = l'UI de questions du terminal (multi-select) ; scripts minimaux |
+| ID8 | Auto-lancement | Hook `SessionStart` du plugin : au **1er lancement** (marqueur absent), injecte un `additionalContext` qui fait lancer l'UX automatiquement → **2 commandes seulement**, pas de `/vibeflow-install` à taper. Mécanisme éprouvé (Superpowers `hooks/session-start`). Nuance : s'active à la session suivant l'install (chargement plugin = restart) |
 | ID6 | Dépendances modules | Auto-résolues + récap avant install ; manifeste **`module.json`** par module (machine-lisible) |
 | ID7 | dev-orchestrator 1er usage | Détecte `.planning/` absent → propose map-codebase puis new-project (sur confirmation) |
 
@@ -55,7 +58,19 @@ ni cloner de repo.
 
 ## 5. Composant — Skill `/vibeflow-install` (ID5, cœur de l'UX)
 
-Skill agent-driven (les toggles = l'UI de questions, pas un TUI bash). Séquence :
+**Auto-lancement (ID8)** : le plugin embarque un hook `SessionStart` (`hooks/hooks.json` +
+script `hooks/session-start`, sur le modèle Superpowers) qui :
+- vérifie un **marqueur de premier lancement** (ex. absence de `~/.claude/.vibeflow-installed` ET
+  de `./.claude/scripts/.vibeflow-installed`) ;
+- si premier lancement → émet `{"hookSpecificOutput": {"hookEventName": "SessionStart",
+  "additionalContext": "<instruction: lance l'UX d'install VibeFlow maintenant>"}}` → l'agent
+  ouvre l'UX automatiquement ;
+- sinon → n'injecte rien (silencieux).
+
+Le skill `/vibeflow-install` reste invocable à la main (re-config, ajout de modules). La logique
+d'UX vit dans le skill ; le hook ne fait que **déclencher** son invocation au 1er lancement.
+
+Séquence du skill (auto-lancé ou manuel) :
 1. **Détecte l'environnement** : GSD/Superpowers déjà présents ? modules déjà installés ? scope existant ?
 2. **Toggle scope** (single-select) : user / project / local.
 3. **Toggle modules** (multi-select) : tous les modules installables + description 1 ligne (depuis `module.json`).
@@ -110,7 +125,7 @@ sur confirmation explicite). Ne lance jamais `gsd-new-project` seul (cohérent B
 - **Phase 1 — Manifeste & résolveur** : `module.json` pour les 8 modules + résolveur de dépendances (fondation, testable isolément).
 - **Phase 2 — Engine scope-aware** : `vibeflow-update.sh` (scope/TARGET_ROOT, source cache plugin, intégration résolveur) + `ensure-deps.sh` scopé.
 - **Phase 3 — Packaging plugin** : `plugin.json`, `marketplace.json`, bundle, doc d'install ; flip repo public (étape confirmée).
-- **Phase 4 — Skill `/vibeflow-install`** : toggles scope + modules, récap dépendances, orchestration engine + GSD + Superpowers.
+- **Phase 4 — Skill `/vibeflow-install` + auto-lancement** : toggles scope + modules, récap dépendances, orchestration engine + GSD + Superpowers ; hook `SessionStart` + marqueur de 1er lancement (ID8) qui ouvre l'UX automatiquement.
 - **Phase 5 — dev-orchestrator first-use** : détection `.planning/` absent + proposition (extension `vf-init`/agent).
 
 Ordre : 1 → 2 → 3/4 (4 dépend de 1+2 ; 3 packaging peut suivre 4) → 5 (indépendant, peut partir tôt).

--- a/docs/superpowers/specs/2026-06-04-install-ux-design.md
+++ b/docs/superpowers/specs/2026-06-04-install-ux-design.md
@@ -60,8 +60,10 @@ ni cloner de repo.
 
 **Auto-lancement (ID8)** : le plugin embarque un hook `SessionStart` (`hooks/hooks.json` +
 script `hooks/session-start`, sur le modèle Superpowers) qui :
-- vérifie un **marqueur de premier lancement** (ex. absence de `~/.claude/.vibeflow-installed` ET
-  de `./.claude/scripts/.vibeflow-installed`) ;
+- vérifie un **marqueur de premier lancement** = le registre que l'engine écrit déjà,
+  `$TARGET_ROOT/scripts/.vibeflow-installed` : absence de `~/.claude/scripts/.vibeflow-installed`
+  (scope user) ET de `./.claude/scripts/.vibeflow-installed` (scope project/local). Le hook LIT
+  ces marqueurs ; c'est l'install qui les pose (pas de nouveau fichier sentinelle) ;
 - si premier lancement → émet `{"hookSpecificOutput": {"hookEventName": "SessionStart",
   "additionalContext": "<instruction: lance l'UX d'install VibeFlow maintenant>"}}` → l'agent
   ouvre l'UX automatiquement ;

--- a/docs/superpowers/specs/2026-06-04-install-ux-design.md
+++ b/docs/superpowers/specs/2026-06-04-install-ux-design.md
@@ -1,0 +1,129 @@
+# Spec — Install UX VibeFlow (plugin + skill à toggles)
+
+> Date : 2026-06-04
+> Statut : design validé (brainstorming), prêt pour milestone GSD
+> Repo : vibeflow-os
+
+## 1. Vision
+
+Réduire l'installation de VibeFlow et de ses modules à **presque aucune étape technique**.
+Cible :
+
+```
+claude plugin marketplace add picmakpro/vibeflow-os
+claude plugin install vibeflow
+/vibeflow-install
+```
+
+Le skill `/vibeflow-install` présente deux listes de toggles dans le terminal — **scope**
+(user/project/local) puis **modules** — et installe tout au bon endroit, dépendances
+auto-résolues. Aucun clone, aucun script à lancer à la main, aucune édition de `settings.json`.
+
+**Objectif mesurable** : depuis zéro, un utilisateur installe le plugin et obtient les modules
+voulus au scope voulu (+ GSD + Superpowers) sans jamais taper de commande shell d'installation
+ni cloner de repo.
+
+## 2. Décisions structurantes (verrouillées)
+
+| # | Décision | Choix |
+|---|----------|-------|
+| ID1 | Bootstrap | Plugin Claude Code (repo = marketplace GitHub) |
+| ID2 | Visibilité repo | **Public** (install zéro-auth). Flip `private→public` = étape délibérée et confirmée au shipping |
+| ID3 | Packaging | Le plugin **bundle tout** (modules + skill + engine + manifeste) ; le skill copie depuis le cache plugin → scope ; **pas de git clone** |
+| ID4 | Scope | **Un seul** choix (user/project/local) appliqué à tout : modules VibeFlow + GSD + Superpowers |
+| ID5 | UX interactive | Skill `/vibeflow-install` ; les "toggles" = l'UI de questions du terminal (multi-select) ; scripts minimaux |
+| ID6 | Dépendances modules | Auto-résolues + récap avant install ; manifeste **`module.json`** par module (machine-lisible) |
+| ID7 | dev-orchestrator 1er usage | Détecte `.planning/` absent → propose map-codebase puis new-project (sur confirmation) |
+
+## 3. Mapping des scopes (ID4)
+
+| Scope | VibeFlow modules | GSD | Superpowers (plugin) |
+|-------|------------------|-----|----------------------|
+| **user** (global) | `~/.claude/` | `npx … --global` | `--scope user` |
+| **project** (commité) | `./.claude/` (suivi git) | `npx … --local` | `--scope project` |
+| **local** (gitignored) | `./.claude/` + ajout `.gitignore` | `npx … --local` | `--scope local` |
+
+## 4. Composant — Plugin `vibeflow` (ID1, ID3)
+
+- `.claude-plugin/plugin.json` (manifeste plugin) + `.claude-plugin/marketplace.json` (entrée marketplace).
+- Le plugin **bundle** : tous les modules (`consolidator`, `infrastructure-audit`, `validator`,
+  `skill-creator`, `reference`, `software-architecture`, `audit-architecture`, `dev-orchestrator`),
+  le skill `/vibeflow-install`, l'engine `vibeflow-update.sh`, le manifeste de dépendances.
+- Install : `claude plugin marketplace add picmakpro/vibeflow-os` → `claude plugin install vibeflow`.
+- Le skill lit les modules depuis le **cache du plugin** (`~/.claude/plugins/cache/.../vibeflow/<v>/`)
+  et les copie au scope choisi. MAJ via `claude plugin update vibeflow`.
+
+## 5. Composant — Skill `/vibeflow-install` (ID5, cœur de l'UX)
+
+Skill agent-driven (les toggles = l'UI de questions, pas un TUI bash). Séquence :
+1. **Détecte l'environnement** : GSD/Superpowers déjà présents ? modules déjà installés ? scope existant ?
+2. **Toggle scope** (single-select) : user / project / local.
+3. **Toggle modules** (multi-select) : tous les modules installables + description 1 ligne (depuis `module.json`).
+4. **Auto-résout les dépendances** (ID6) → **récap** ("validator entraîne consolidator + infrastructure-audit").
+5. **Installe** au scope choisi, en déléguant à l'engine :
+   - Modules VibeFlow → engine `install` scope-aware.
+   - GSD + Superpowers → `ensure-deps.sh` scopé (si `dev-orchestrator` sélectionné, ou sur demande).
+   - Si scope `local` → ajoute les chemins au `.gitignore`.
+6. **Récap final** + prochaines étapes (ex. « dis "aide-moi à dev" pour démarrer »).
+
+## 6. Composant — Engine `vibeflow-update.sh` scope-aware (ID3, ID4)
+
+- Paramètre **`VF_SCOPE`** / `--scope user|project|local` → résout `TARGET_ROOT` :
+  `user`→`$HOME/.claude`, `project`/`local`→`./.claude` ; `local` ajoute aussi au `.gitignore`.
+- **Source = cache du plugin** (variable `VIBEFLOW_CACHE` pointant sur le dossier d'install du plugin)
+  au lieu du `git clone` → suppression de la logique `.vibeflow-cache`/`ensure_cache` clone.
+- **Résolveur de dépendances** : lit les `module.json`, calcule la fermeture transitive des `requires`.
+- `install` / `update` / `uninstall` / `status` deviennent **scope-aware** (cibles selon `TARGET_ROOT`).
+- Rétro-compat : un appel sans scope par défaut sur `project` (`./.claude`) = comportement actuel.
+
+## 7. Composant — Manifeste `module.json` + résolveur (ID6)
+
+Chaque module gagne un `module.json` à sa racine :
+```json
+{
+  "name": "validator",
+  "version": "v1.1.0",
+  "type": "agent-only",
+  "description": "Agent garant de l'alignement méthodo ↔ lab (5 audits).",
+  "requires": ["consolidator", "infrastructure-audit"]
+}
+```
+Source de vérité machine-lisible (remplace la prose des READMEs). Le skill agrège tous les
+`module.json` pour : la liste à toggles (nom + description), et l'auto-résolution (`requires`).
+
+## 8. Composant — `ensure-deps.sh` scopé (ID4)
+
+Aujourd'hui figé `--global` (GSD) / `--scope user` (Superpowers). Devient paramétrable via `VF_SCOPE` :
+- GSD : `user`→`--global`, `project`/`local`→`--local`.
+- Superpowers : `claude plugin install superpowers@claude-plugins-official --scope <user|project|local>`.
+- Idempotence et fallback manuel inchangés.
+
+## 9. Composant — dev-orchestrator first-use detection (ID7)
+
+Étendre `vf-init` / l'agent `vibeflow-dev` : au premier usage, si `.planning/PROJECT.md` (ou
+`.planning/`) est **absent**, l'agent le détecte et **propose** : cartographier le code existant
+(`gsd-map-codebase`, non-interactif si du code existe) puis démarrer le projet (`gsd-new-project`,
+sur confirmation explicite). Ne lance jamais `gsd-new-project` seul (cohérent BOOT-04 du module).
+
+## 10. Découpage en phases (milestone GSD)
+
+- **Phase 1 — Manifeste & résolveur** : `module.json` pour les 8 modules + résolveur de dépendances (fondation, testable isolément).
+- **Phase 2 — Engine scope-aware** : `vibeflow-update.sh` (scope/TARGET_ROOT, source cache plugin, intégration résolveur) + `ensure-deps.sh` scopé.
+- **Phase 3 — Packaging plugin** : `plugin.json`, `marketplace.json`, bundle, doc d'install ; flip repo public (étape confirmée).
+- **Phase 4 — Skill `/vibeflow-install`** : toggles scope + modules, récap dépendances, orchestration engine + GSD + Superpowers.
+- **Phase 5 — dev-orchestrator first-use** : détection `.planning/` absent + proposition (extension `vf-init`/agent).
+
+Ordre : 1 → 2 → 3/4 (4 dépend de 1+2 ; 3 packaging peut suivre 4) → 5 (indépendant, peut partir tôt).
+
+## 11. Hors scope (YAGNI)
+
+- Migration automatique d'un scope à l'autre (réinstaller dans l'autre scope = manuel pour l'instant).
+- Désinstallation/rollback scope-aware avancée (on garde le comportement actuel, juste cible adaptée).
+- UI graphique : on reste CLI/skill-driven.
+- Versioning indépendant des modules vs plugin (le plugin embarque une version figée par release).
+
+## 12. Risques / points ouverts
+
+- **Flip public (ID2)** : action quasi-irréversible (contenu visible). À exécuter délibérément en Phase 3, sur confirmation explicite, jamais en douce.
+- **`marketplace add` repo privé→public** : valider en Phase 3 que `claude plugin marketplace add picmakpro/vibeflow-os` fonctionne réellement zéro-auth une fois public.
+- **Coexistence plugin ↔ modules copiés** : le plugin fournit le skill+engine+cache ; les modules vivent ensuite dans `~/.claude` ou `./.claude` selon scope — vérifier l'absence de double-chargement (skill du plugin vs skills copiés).

--- a/docs/superpowers/specs/SHIPPING-CHECKLIST.md
+++ b/docs/superpowers/specs/SHIPPING-CHECKLIST.md
@@ -1,0 +1,167 @@
+# SHIPPING-CHECKLIST — VibeFlow plugin public
+
+> ⚠️ **Ce document est une PROCÉDURE CONFIRMÉE HORS-AGENT pour les étapes §2 et §3.**
+> Aucun agent autonome ne doit exécuter le flip public (`gh repo edit … --visibility public`)
+> ni l'install du plugin. Ces actions sont **délibérées, quasi-irréversibles** et lancées
+> **à la main par l'utilisateur** après confirmation (spec §12, décision ID2).
+>
+> L'executor du Plan 05-02 a uniquement : rédigé ce document et exécuté les vérifications
+> §1 en **LECTURE SEULE** pour pré-cocher l'état constaté. Aucune visibilité de repo n'a été
+> modifiée, aucune install réelle n'a été lancée.
+
+Repo cible : `picmakpro/vibeflow-os`
+Plugin : `vibeflow` (marketplace `vibeflow-os`)
+Couvre : **PLUG-03** (flip public — documenté/gated) + **PLUG-04** (validation zéro-auth — documentée/gated).
+Critère de succès Phase 5 #2 : « marketplace add + install fonctionnent en zéro-auth ».
+
+---
+
+## §1 — Checklist pré-public (à VALIDER AVANT le flip)
+
+État constaté par l'audit en lecture seule du **2026-06-04** (HEAD au moment de l'exécution du Plan 05-02).
+
+- [x] **Aucun secret dans l'historique ni l'arbre de travail.**
+  - `git log --all --oneline | wc -l` → **50 commits** audités.
+  - Scan motifs sensibles sur l'historique complet (`git log --all -p`) : motifs
+    `AKIA[0-9A-Z]{16}`, `-----BEGIN … PRIVATE KEY-----`, `ghp_/gho_/ghu_/ghs_/ghr_…`,
+    `sk-…`, `xox[baprs]-…`, et assignations `api_key|secret|token|password = <valeur ≥16 car.>`
+    → **0 correspondance réelle**.
+  - Le grep large (`AKIA|api_key|secret|token|password|-----BEGIN`) renvoie ~267 lignes,
+    **toutes** issues de la **prose de planification** (specs, plans, threat models, et la
+    commande d'audit elle-même). **Aucune** n'est un credential. Statut : **CLEAN**.
+  - Fichiers sensibles à la racine et dans les modules (`.env*`, `*.p8`, `*.p12`, `*.cer`,
+    `*credentials*`, `id_rsa*`) → **AUCUN trouvé**.
+  - Recommandation : ce scan reste valable tant qu'aucun nouveau commit n'est ajouté.
+    **Re-lancer le scan juste avant le flip** si des commits ont été poussés depuis.
+
+- [x] **`LICENSE` présent à la racine et cohérent avec `plugin.json`.**
+  - `LICENSE` présent (259 o) : `Copyright (c) 2026 picmakpro — All rights reserved`,
+    « proprietary modules… restricted to authorized labs only ».
+  - `plugin.json` → `"license": "UNLICENSED"`. ✅ **Cohérent** : pas de licence open-source
+    accordée.
+  - ⚠️ **Conséquence d'un repo rendu public avec cette LICENSE** : le repo devient
+    **source-available**, pas open-source. Le **code et l'historique sont visibles** par
+    quiconque, mais **aucun droit de réutilisation, modification ou redistribution n'est
+    accordé** (« All rights reserved »). C'est un choix délibéré : la visibilité publique
+    sert l'installation zéro-auth via marketplace, **sans** céder de droits. À confirmer
+    explicitement avant le flip — si l'intention est d'autoriser la réutilisation, il faut
+    d'abord changer la LICENSE et `plugin.json`.
+
+- [x] **Manifestes valides.**
+  - `jq empty .claude-plugin/plugin.json` → **VALID JSON**.
+  - `jq empty .claude-plugin/marketplace.json` → **VALID JSON**.
+  - `plugin.json` : `name: vibeflow`, `version: 2.3.0`, `skills: ./installer`,
+    `hooks: ./installer/hooks/hooks.json`.
+  - `marketplace.json` : `name: vibeflow-os`, plugin `vibeflow` `source: ./`,
+    `version: 2.3.0` (aligné avec `plugin.json`).
+  - **À cocher avant le flip** : revalider avec `claude plugin validate .` (validateur
+    officiel Claude Code, cf. verify du Plan 05-01) sur la machine de shipping.
+
+- [x] **`.gitignore` couvre caches/artefacts.**
+  - Couvre `.vibeflow-cache/`, `.backups/`, `*.bak`/`*.bak-*`, `*.log`/`logs/`,
+    `.DS_Store`/`._*`, `__pycache__/`/`*.pyc`, `.vscode/`/`.idea/`/`*.swp`.
+  - ✅ Rien de sensible ni d'artefact runtime n'est censé être committé.
+
+- [ ] **README / INSTALL à jour (flux 2-commandes, plus de clone manuel).**
+  - ⚠️ **ACTION REQUISE AVANT/AU FLIP** : `README.md` mentionne encore le statut **« Privé »** :
+    - ligne 4 : `> Privé. Maintenu par @picmakpro.`
+    - ligne 105 : `- Repo privé`
+    - ligne 124 : référence au lab principal `vibeflow-lab` (privé) — à conserver tel quel
+      si ce lab reste privé.
+  - Mettre à jour les mentions « Privé / Repo privé » du README **avant** ou **au moment**
+    du flip public, pour ne pas laisser une doc qui contredit la visibilité réelle.
+  - Vérifier que `INSTALL.md` décrit bien le flux **2 commandes** (`marketplace add` + `install`)
+    et non plus un clone manuel (livré au Plan 05-01).
+
+> **Pré-condition du flip (§2)** : tous les items §1 doivent être cochés, en particulier
+> le README mis à jour et le scan secrets re-confirmé si de nouveaux commits ont été ajoutés.
+
+---
+
+## §2 — Étape MANUELLE confirmée hors-agent : flip public (PLUG-03)
+
+> ⛔ **AVERTISSEMENT — ACTION QUASI-IRRÉVERSIBLE.**
+> Rendre le repo public expose **tout le contenu ET tout l'historique git** de façon
+> permanente (un repo re-privatisé reste considéré comme ayant été exposé). Cette action
+> est **délibérée**, **confirmée explicitement par l'utilisateur**, et **JAMAIS lancée par
+> un agent autonome**. L'executor s'arrête au checkpoint et ne touche pas à la visibilité.
+
+**Pré-condition** : toute la checklist §1 cochée (secrets clean, LICENSE OK + conséquence
+source-available assumée, manifestes valides, `.gitignore` propre, README mis à jour).
+
+**Commande EXACTE à lancer par l'utilisateur** (ou par l'orchestrateur sur confirmation
+explicite, hors de tout executor autonome) :
+
+```bash
+gh repo edit picmakpro/vibeflow-os --visibility public --accept-visibility-change-consequences
+```
+
+**Vérification** : sur GitHub, confirmer que `picmakpro/vibeflow-os` est bien public, ou :
+
+```bash
+gh repo view picmakpro/vibeflow-os --json visibility   # doit renvoyer {"visibility":"PUBLIC"}
+```
+
+> État au moment de la rédaction : `gh repo view picmakpro/vibeflow-os --json visibility`
+> → `{"visibility":"PRIVATE"}` (repo **non** rendu public par le Plan 05-02 — conforme).
+
+---
+
+## §3 — Validation post-public : zéro-auth (PLUG-04)
+
+À lancer **APRÈS** le flip §2, **par l'utilisateur**, idéalement depuis une machine **sans
+auth GitHub** configurée pour ce repo (pour prouver le zéro-auth).
+
+**Commandes EXACTES :**
+
+```bash
+claude plugin marketplace add picmakpro/vibeflow-os
+claude plugin install vibeflow
+```
+
+**Résultat attendu** : l'ajout du marketplace et l'install réussissent **SANS
+authentification GitHub** (repo public). À la **session suivante**, le hook `SessionStart`
+ouvre **`/vibeflow-install`** automatiquement (1er lancement, marqueur d'install absent).
+
+**Critères de validation (à cocher APRÈS exécution réelle, hors-agent) :**
+
+- [ ] `claude plugin marketplace add picmakpro/vibeflow-os` réussit sans demander d'auth.
+- [ ] `claude plugin install vibeflow` installe le plugin.
+- [ ] `claude plugin details vibeflow` liste le skill `vibeflow-install` et le hook `SessionStart`.
+- [ ] Nouvelle session Claude Code → l'UX `/vibeflow-install` s'ouvre automatiquement.
+
+### Dépannage zéro-auth (IMPORTANT — pour que PLUG-04 ne soit pas une impasse)
+
+Si `claude plugin marketplace add` sur le repo **fraîchement public** demande **ENCORE** une
+authentification GitHub (cause probable : **cache GitHub côté Claude Code** OU **lag de
+ré-indexation** du marketplace après le flip), dérouler cette procédure **avant** de conclure
+à un échec :
+
+1. **Purger l'entrée mise en cache :**
+   ```bash
+   claude plugin marketplace remove vibeflow-os
+   ```
+2. **Re-add → re-fetch propre :**
+   ```bash
+   claude plugin marketplace add picmakpro/vibeflow-os
+   ```
+3. **Vérifier que la visibilité publique est bien propagée côté GitHub :**
+   ```bash
+   gh repo view picmakpro/vibeflow-os --json visibility   # doit renvoyer "PUBLIC"
+   ```
+4. **Si la visibilité est correcte (`PUBLIC`) mais que l'auth persiste** : attendre **quelques
+   minutes** (ré-indexation marketplace côté GitHub), puis **re-tenter le remove + add**.
+
+> ❗ Ne **PAS** considérer **PLUG-04 comme échoué** tant que cette procédure (remove + re-add
+> + vérif visibilité + attente ré-indexation) n'a pas été déroulée intégralement.
+
+---
+
+## Récapitulatif des dispositions de sécurité (threat model 05-02)
+
+| Threat | Disposition | Couverture dans ce doc |
+|--------|-------------|------------------------|
+| T-05-05 secrets exposés au flip | mitigate | §1 audit secrets (clean) AVANT flip ; flip gated tant que §1 non cochée |
+| T-05-06 exécution autonome irréversible | mitigate | §2 = checkpoint:human-action ; aucune commande de visibilité en task `auto` |
+| T-05-07 flip non confirmé tracé | accept | confirmation explicite via resume-signal du checkpoint (STATE/SUMMARY) |
+| T-05-09 auth résiduelle → PLUG-04 impasse | mitigate | §3 dépannage zéro-auth (remove + re-add + vérif visibilité + attente) |

--- a/infrastructure-audit/module.json
+++ b/infrastructure-audit/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "infrastructure-audit",
+  "version": "v1.0.0",
+  "type": "single-skill+scripts",
+  "description": "Garde-fou technique des labs (drift Anthropic, intégrité scripts).",
+  "requires": []
+}

--- a/installer/SKILL.md
+++ b/installer/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: vibeflow-install
+description: >
+  Utiliser au tout premier lancement de VibeFlow après l'installation du plugin (le hook
+  SessionStart de 1er lancement invoque ce skill automatiquement), ou quand l'utilisateur dit
+  « installe VibeFlow », « configure les modules », « ajoute un module », « change de scope »,
+  « re-configure VibeFlow », ou veut choisir où installer (compte / projet / projet sans commit).
+  Invocable par l'utilisateur ET par l'agent en autonomie.
+---
+
+# vibeflow-install — Orchestration de l'install à toggles
+
+Skill **orchestrateur thin** : il décrit la séquence d'UX et **DÉLÈGUE** à des briques déjà
+livrées (catalogue, résolveur de deps, engine scope-aware, bootstrap GSD/Superpowers). Il ne
+réimplémente RIEN — pas de TUI bash, pas de logique de copie, pas de gitignore maison.
+
+Ce skill est de la **PROSE agent-driven** : le routage/UX réel se valide en session (comme le
+first-use). Seules les briques déléguées sont testées unitairement.
+
+## Séquence
+
+1. **Détection environnement.** GSD / Superpowers présents ? Modules déjà installés
+   (`vibeflow-update.sh status`, avec `VIBEFLOW_CACHE` = cache du plugin) ? Un scope déjà
+   utilisé précédemment ? Sert à pré-cocher / informer, pas à décider à la place de l'utilisateur.
+
+2. **Toggle scope (INST-01 — single-select).** Proposer **un seul** choix parmi
+   `user` / `project` / `local`, via l'UI de questions du terminal (AskUserQuestion / toggles),
+   **PAS** un TUI bash. Un et un seul scope est retenu (cohérence **ID4** : le même scope
+   s'applique à tout — modules VibeFlow + GSD + Superpowers). Reframe pour l'utilisateur :
+   compte (user) / projet (project) / projet sans commit (local).
+
+3. **Toggle modules (INST-02 — multi-select).** Peupler la liste à partir de
+   `build-module-catalog.sh` (`VF_MODULES_ROOT` = cache du plugin) : chaque entrée = nom + la
+   description 1 ligne issue de son `module.json`. **Aucun nom de module en dur** — tout sort du
+   catalogue.
+
+4. **Auto-résolution + récap (INST-03).** Passer la sélection à `resolve-deps.sh`
+   (`VF_MODULES_ROOT` = cache) pour la **fermeture transitive** des `requires`, puis
+   **RÉCAPITULER explicitement** à l'utilisateur ce que ça entraîne (ex. « validator entraîne
+   aussi consolidator + infrastructure-audit ») **AVANT** toute install. L'utilisateur voit la
+   liste complète des modules qui seront posés.
+
+5. **Install scopée (INST-04 — déléguée, scope unique partout).**
+   - **Modules VibeFlow** → `vibeflow-update.sh --scope <s> install --with-deps <module>` (ou
+     itérer la fermeture déjà résolue), avec `VIBEFLOW_CACHE` pointant sur le cache du plugin.
+     `--with-deps` recâble lui-même le résolveur côté engine.
+   - **GSD + Superpowers** → `VF_SCOPE=<s> ensure-deps.sh` (si dev-orchestrator est sélectionné,
+     ou sur demande). **PASSER TOUJOURS un VF_SCOPE explicite** = `<s>`, le scope choisi à
+     l'étape 2 (cohérence **ID4** — on ne laisse jamais le défaut LEGACY décider).
+   - Scope `local` → le `.gitignore` est géré **par l'engine** (SCOPE-04, déjà fait) : ne pas le
+     réimplémenter, juste le mentionner à l'utilisateur (« rien ne sera committé »).
+
+6. **Récap final + prochaines étapes.** Confirmer ce qui a été posé et où, puis amorcer la suite
+   en vocabulaire VibeFlow (ex. « dis "aide-moi à dev" pour démarrer »).
+
+## Garde-fous
+
+- **`VF_SCOPE` explicite partout** : ne jamais s'appuyer sur le défaut LEGACY de l'engine
+  (`project`) ni de `ensure-deps.sh` (`user`). Un scope unique, choisi une fois, propagé à
+  l'engine **et** à `ensure-deps.sh` (ID4).
+- **Ne réimplémente jamais** une brique : route et délègue (catalogue, `resolve-deps.sh`,
+  `vibeflow-update.sh --scope`, `ensure-deps.sh` via `VF_SCOPE`).
+- **Reframe en vocabulaire VibeFlow** ; ne nomme jamais GSD ni Superpowers à l'utilisateur
+  (cohérent vf-init / ABS-02).

--- a/installer/SKILL.md
+++ b/installer/SKILL.md
@@ -17,6 +17,42 @@ réimplémente RIEN — pas de TUI bash, pas de logique de copie, pas de gitigno
 Ce skill est de la **PROSE agent-driven** : le routage/UX réel se valide en session (comme le
 first-use). Seules les briques déléguées sont testées unitairement.
 
+## Câblage du cache (à appliquer pour CHAQUE délégation — étapes 1, 3, 4, 5)
+
+En contexte plugin, Claude Code fournit `${CLAUDE_PLUGIN_ROOT}` : le chemin absolu du dossier
+d'install du plugin (= le **cache**). C'est là que vivent les modules, leurs `module.json` à la
+racine, et le dossier `_internal/` (engine + résolveur). L'engine attend ce chemin dans deux
+variables :
+
+- `VIBEFLOW_CACHE` — source unique du cache pour `vibeflow-update.sh` (`status`, `install`).
+- `VF_MODULES_ROOT` — racine des modules pour `build-module-catalog.sh` et `resolve-deps.sh`.
+
+**Convention de résolution (avec fallback dev)** — toujours exporter ces variables ainsi avant
+de déléguer à un script :
+
+```sh
+VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-<racine du repo vibeflow-os cloné en dev>}"
+VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-<racine du repo vibeflow-os cloné en dev>}"
+```
+
+- **En plugin installé** : `${CLAUDE_PLUGIN_ROOT}` est défini → les deux variables pointent sur le
+  cache bundlé.
+- **En dev (repo cloné, pas plugin)** : `CLAUDE_PLUGIN_ROOT` est absent → le fallback pointe les
+  deux variables sur la racine du repo `vibeflow-os` (comportement déjà supporté par les scripts :
+  `VF_MODULES_ROOT` défaut = racine repo ; `VIBEFLOW_CACHE` défaut `.vibeflow-cache`, donc en dev
+  on le pointe explicitement sur la racine du repo).
+
+Concrètement, par étape :
+
+- **étape 1 (status)** : `VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-…}" vibeflow-update.sh status`
+- **étape 3 (catalogue)** : `VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-…}" build-module-catalog.sh`
+- **étape 4 (résolveur)** : `VF_MODULES_ROOT="${CLAUDE_PLUGIN_ROOT:-…}" resolve-deps.sh …`
+- **étape 5 (install)** :
+  `VIBEFLOW_CACHE="${CLAUDE_PLUGIN_ROOT:-…}" vibeflow-update.sh --scope <s> install --with-deps <module>`
+
+`_internal/resolve-deps.sh` est **bundlé dans le plugin** (présent dans le cache `${CLAUDE_PLUGIN_ROOT}`)
+→ `--with-deps` fonctionne réellement après une install plugin (lève le warning Phase 3).
+
 ## Séquence
 
 1. **Détection environnement.** GSD / Superpowers présents ? Modules déjà installés

--- a/installer/hooks/hooks.json
+++ b/installer/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start\"",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/installer/hooks/hooks.json
+++ b/installer/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start\"",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/installer/hooks/session-start\"",
             "async": false
           }
         ]

--- a/installer/hooks/session-start
+++ b/installer/hooks/session-start
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SessionStart hook for VibeFlow plugin.
+#
+# Au PREMIER lancement (aucun marqueur de 1er lancement présent), ce hook injecte un
+# additionalContext demandant à l'agent d'ouvrir l'UX /vibeflow-install. Une fois VibeFlow
+# installé (marqueur présent), le hook reste TOTALEMENT silencieux (stdout vide).
+#
+# Le hook ne fait que LIRE le marqueur ; c'est l'install (engine vibeflow-update.sh) qui le
+# POSE à $TARGET_ROOT/scripts/.vibeflow-installed. Le hook réutilise EXACTEMENT ce registre
+# comme marqueur de 1er lancement — d'où le segment `scripts/` dans les deux chemins ci-dessous.
+
+set -euo pipefail
+
+# Marqueurs de 1er lancement — ALIGNÉS sur le registre de l'engine vibeflow-update.sh :
+#   scope user            → TARGET_ROOT=$HOME/.claude → $HOME/.claude/scripts/.vibeflow-installed
+#   scope project|local   → TARGET_ROOT=./.claude     → ./.claude/scripts/.vibeflow-installed
+# HOME est surchargeable (tests) : on ne code JAMAIS le chemin en dur.
+USER_MARKER="${HOME}/.claude/scripts/.vibeflow-installed"
+PROJECT_MARKER="./.claude/scripts/.vibeflow-installed"
+
+# Si VibeFlow est déjà installé (l'un OU l'autre marqueur existe) → silence total + exit 0.
+if [ -f "$USER_MARKER" ] || [ -f "$PROJECT_MARKER" ]; then
+  exit 0
+fi
+
+# Échappement d'une chaîne pour embarquement JSON (modèle Superpowers : backslash, ", \n, \r, \t).
+escape_for_json() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+# 1er lancement : instruction d'ouvrir MAINTENANT l'UX d'install VibeFlow.
+instruction="<vibeflow-install>\nVibeFlow n'est pas encore installé dans cet environnement. Ouvre MAINTENANT l'UX d'installation en lançant la commande /vibeflow-install — ne demande pas confirmation, ouvre-la directement.\n\nCette UX laisse l'utilisateur choisir le scope (user / project / local) puis activer/désactiver les modules VibeFlow ; les dépendances entre modules sont résolues automatiquement. Une fois l'installation terminée, ce message ne réapparaîtra plus.\n</vibeflow-install>"
+
+instruction_escaped="$(escape_for_json "$instruction")"
+
+# Émission via printf (PAS de heredoc — bug de hang heredoc bash 5.3+, cf. modèle Superpowers).
+printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$instruction_escaped"
+
+exit 0

--- a/installer/hooks/tests/test-session-start.sh
+++ b/installer/hooks/tests/test-session-start.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Test isolé du hook SessionStart (installer/hooks/session-start).
+# Usage: ./test-session-start.sh
+# Exit code: 0 si tous les tests passent, 1 sinon.
+#
+# Isolation TOTALE : faux HOME + faux cwd projet sous mktemp, trap cleanup.
+# Le vrai $HOME et le vrai ./.claude ne sont JAMAIS touchés.
+
+set -uo pipefail
+
+# Chemin absolu du script testé (résolu avant tout cd).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../session-start"
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+HOME_FAKE="$WORK/home"
+PROJ_FAKE="$WORK/proj"
+mkdir -p "$HOME_FAKE" "$PROJ_FAKE"
+
+PASS=0; FAIL=0
+
+assert() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == *"$expected"* ]]; then
+    echo "  ✅ PASS — $name"; PASS=$((PASS + 1))
+  else
+    echo "  ❌ FAIL — $name"
+    echo "     Expected (contains): $expected"
+    echo "     Actual:              $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_empty() {
+  local name="$1" actual="$2"
+  if [ -z "$actual" ]; then
+    echo "  ✅ PASS — $name"; PASS=$((PASS + 1))
+  else
+    echo "  ❌ FAIL — $name (stdout non vide)"
+    echo "     Actual: $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Exécute le hook dans l'isolation : cwd=$PROJ_FAKE, HOME=$HOME_FAKE.
+run_hook() {
+  ( cd "$PROJ_FAKE" && HOME="$HOME_FAKE" bash "$HOOK" )
+}
+
+echo "=== T1 — 1er lancement (aucun marqueur) : émet additionalContext ==="
+out="$(run_hook)"; rc=$?
+assert "T1.1 — exit code 0" "$rc" "0"
+assert "T1.2 — contient additionalContext" "$out" "additionalContext"
+assert "T1.3 — nomme /vibeflow-install" "$out" "vibeflow-install"
+if printf '%s' "$out" | jq . >/dev/null 2>&1; then
+  echo "  ✅ PASS — T1.4 — sortie JSON parsable"; PASS=$((PASS + 1))
+else
+  echo "  ❌ FAIL — T1.4 — sortie JSON NON parsable"; FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== T2 — marqueur user présent : silence (garde-fou user-scope) ==="
+mkdir -p "$HOME_FAKE/.claude/scripts"
+: > "$HOME_FAKE/.claude/scripts/.vibeflow-installed"
+out="$(run_hook)"; rc=$?
+assert "T2.1 — exit code 0" "$rc" "0"
+assert_empty "T2.2 — stdout VIDE" "$out"
+
+echo ""
+echo "=== T3 — marqueur project présent : silence ==="
+# Nettoyer le marqueur user pour isoler le cas project.
+rm -f "$HOME_FAKE/.claude/scripts/.vibeflow-installed"
+mkdir -p "$PROJ_FAKE/.claude/scripts"
+: > "$PROJ_FAKE/.claude/scripts/.vibeflow-installed"
+out="$(run_hook)"; rc=$?
+assert "T3.1 — exit code 0" "$rc" "0"
+assert_empty "T3.2 — stdout VIDE" "$out"
+
+echo ""
+echo "=== BILAN ==="
+echo "PASS : $PASS / FAIL : $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/installer/scripts/build-module-catalog.sh
+++ b/installer/scripts/build-module-catalog.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# build-module-catalog.sh — Catalogue nom + description agrégé depuis les module.json.
+#
+# Pour chaque sous-dossier de la racine modules qui contient un `module.json`, émet sur
+# stdout une ligne au format :   <name>\t<description>
+#   (séparateur = TABULATION ; un module par ligne, trié alphabétiquement par nom).
+#
+# Source EXCLUSIVE = `jq -r` sur les champs `.name` et `.description` de chaque module.json.
+# AUCUN nom de module n'est codé en dur (anti-hallucination, cf. build-gsd-index.sh) : la
+# liste sort entièrement des fichiers présents sur le disque. Les dossiers sans module.json
+# (ex. `_internal`, `docs`, `installer`) sont naturellement exclus.
+#
+# Ce catalogue est consommé par le skill /vibeflow-install pour peupler le toggle modules
+# (INST-02). C'est une brique de DONNÉES (pas d'UX) : on la garde minimale.
+#
+# Racine des modules : ${VF_MODULES_ROOT:-<racine repo = parent de installer/scripts>}.
+#   Surchargeable via VF_MODULES_ROOT pour injecter des fixtures de test (cohérent avec
+#   resolve-deps.sh). Le défaut pointe sur la racine du repo, où vivent les 8 module.json.
+set -euo pipefail
+
+log() { echo "[build-module-catalog] $*" >&2; }
+err() { echo "[build-module-catalog] ERROR: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || err "jq introuvable (requis pour parser les module.json)"
+
+ROOT="${VF_MODULES_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+[ -d "$ROOT" ] || err "racine modules introuvable : $ROOT"
+
+# Parcourt chaque module.json, émet "name<TAB>description", puis trie par nom.
+for manifest in "$ROOT"/*/module.json; do
+  [ -f "$manifest" ] || continue
+  name=$(jq -r '.name // empty' "$manifest")
+  description=$(jq -r '.description // empty' "$manifest")
+  [ -n "$name" ] || continue
+  printf '%s\t%s\n' "$name" "$description"
+done | sort

--- a/installer/scripts/tests/test-build-module-catalog.sh
+++ b/installer/scripts/tests/test-build-module-catalog.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Test de build-module-catalog.sh — ISOLÉ (fixtures mktemp via VF_MODULES_ROOT) + cas repo réel.
+# Convention TESTING.md / modèle test-resolve-deps.sh. zsh aliase grep → on invoque le script
+# via `bash` et on utilise `command grep` pour ne jamais hériter d'un alias.
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/build-module-catalog.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+pass=0; fail=0
+ok() { echo "  ✓ $1"; pass=$((pass+1)); }
+ko() { echo "  ✗ $1"; fail=$((fail+1)); }
+
+echo "== test-build-module-catalog =="
+
+# ---------- Fixture isolée : 2 modules avec module.json + 1 dossier SANS module.json ----------
+FIX=$(mktemp -d)
+trap 'rm -rf "$FIX"' EXIT
+
+mkdir -p "$FIX/zeta" "$FIX/alpha" "$FIX/sans-manifeste"
+cat > "$FIX/zeta/module.json" <<'JSON'
+{ "name": "zeta", "version": "v1.0.0", "type": "single-skill", "description": "Module Zeta de test.", "requires": [] }
+JSON
+cat > "$FIX/alpha/module.json" <<'JSON'
+{ "name": "alpha", "version": "v1.0.0", "type": "single-skill", "description": "Module Alpha de test.", "requires": [] }
+JSON
+# Dossier volontairement SANS module.json — doit être exclu du catalogue.
+: > "$FIX/sans-manifeste/README.md"
+
+fix_out=$(VF_MODULES_ROOT="$FIX" bash "$SCRIPT" 2>/dev/null)
+
+# (a) sortie triée : alpha avant zeta
+first=$(printf '%s\n' "$fix_out" | head -1 | cut -f1)
+[ "$first" = "alpha" ] && ok "fixture : sortie triée (alpha en premier)" \
+  || ko "fixture : tri attendu alpha en premier, obtenu [$first]"
+
+# (b) dossier sans module.json exclu (jamais de ligne 'sans-manifeste')
+if printf '%s\n' "$fix_out" | command grep -q '^sans-manifeste'; then
+  ko "fixture : le dossier sans module.json ne doit PAS apparaître"
+else
+  ok "fixture : dossier sans module.json exclu"
+fi
+
+# (c) chaque ligne a une description non vide (champ 2 après TAB)
+desc_ok=1
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  d=$(printf '%s' "$line" | cut -f2)
+  [ -n "$d" ] || desc_ok=0
+done <<< "$fix_out"
+[ "$desc_ok" -eq 1 ] && ok "fixture : chaque ligne a une description non vide" \
+  || ko "fixture : au moins une description vide"
+
+# Compte de modules de la fixture = 2 (alpha + zeta)
+nfix=$(printf '%s\n' "$fix_out" | command grep -c .)
+[ "$nfix" -eq 2 ] && ok "fixture : 2 modules listés" \
+  || ko "fixture : attendu 2 modules, obtenu $nfix"
+
+# ---------- Cas repo réel : exactement 8 modules, validator + sa description présents ----------
+real_out=$(VF_MODULES_ROOT="$REPO_ROOT" bash "$SCRIPT" 2>/dev/null)
+
+nreal=$(printf '%s\n' "$real_out" | command grep -c .)
+[ "$nreal" -eq 8 ] && ok "repo réel : 8 modules listés" \
+  || ko "repo réel : attendu 8 modules, obtenu $nreal"
+
+# validator présent ET avec une description non vide
+vline=$(printf '%s\n' "$real_out" | command grep '^validator	' || true)
+if [ -n "$vline" ] && [ -n "$(printf '%s' "$vline" | cut -f2)" ]; then
+  ok "repo réel : validator présent avec description"
+else
+  ko "repo réel : validator + description attendus, obtenu [$vline]"
+fi
+
+echo "== résultat : $pass OK / $fail KO =="
+[ "$fail" -eq 0 ]

--- a/reference/module.json
+++ b/reference/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "reference",
+  "version": "v2.1.1",
+  "type": "doc-only",
+  "description": "Documentation méthodologique VibeFlow (module doc-only).",
+  "requires": []
+}

--- a/skill-creator/module.json
+++ b/skill-creator/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "skill-creator",
+  "version": "v1.0.0",
+  "type": "agent+skills",
+  "description": "Pattern agent minimal + 2 skills composables pour créer des skills.",
+  "requires": []
+}

--- a/software-architecture/module.json
+++ b/software-architecture/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "software-architecture",
+  "version": "v1.0.0",
+  "type": "single-skill+scripts",
+  "description": "Garde-fou d'architecture logicielle (taille fichiers, règles).",
+  "requires": []
+}

--- a/validator/module.json
+++ b/validator/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "validator",
+  "version": "v1.1.0",
+  "type": "agent-only",
+  "description": "Agent garant de l'alignement lab ↔ méthodologie (5 audits).",
+  "requires": ["consolidator", "infrastructure-audit"]
+}


### PR DESCRIPTION
## Milestone Install UX — installation VibeFlow en 2 commandes

Transforme l'installation de VibeFlow + modules en **plugin Claude Code** avec UX à toggles auto-lancée. Cible :

```
claude plugin marketplace add picmakpro/vibeflow-os
claude plugin install vibeflow
# → au prochain démarrage, l'UX d'install s'ouvre automatiquement
```

Spec : `docs/superpowers/specs/2026-06-04-install-ux-design.md`.

### Phases livrées
- ✅ **Phase 2 — Manifeste & résolveur** : `module.json` pour les 8 modules + `_internal/resolve-deps.sh` (fermeture transitive). MANIF-01/02.
- ✅ **Phase 3 — Engine scope-aware** : `vibeflow-update.sh` (`--scope user|project|local`, TARGET_ROOT, clone git supprimé, `.gitignore` local, résolveur câblé) + `ensure-deps.sh` scopé. Rétro-compat garantie. SCOPE-01..04.
- ✅ **Phase 4 — Skill `/vibeflow-install` + auto-lancement** : catalogue des modules + skill orchestrateur (toggle scope → toggle modules → récap déps → install scopée) + hook `SessionStart` (marqueur 1er lancement). INST-01..05.
- ✅ **Phase 5 (partiel) — Packaging plugin** : `plugin.json` + `marketplace.json` (`claude plugin validate` ✅), câblage `VIBEFLOW_CACHE=${CLAUDE_PLUGIN_ROOT}`, README/INSTALL en flux 2-commandes. PLUG-01/02.

### En attente (hors-agent / post-merge)
- ⏸ **PLUG-03 — flip repo public** : nécessite les droits **admin** du propriétaire `picmakpro` (le CLI actuel a WRITE seulement). À faire par le mainteneur. Repo = source-available (LICENSE propriétaire conservée).
- ⏸ **PLUG-04 — validation zéro-auth** : dépend du flip public **et** de ce merge (le `marketplace add` lit la branche par défaut). À valider après merge + flip.
- 🔜 **Phase 6 — dev-orchestrator first-use** : détection `.planning/` absent → proposition d'init. Sera ajoutée à cette branche avant merge.

Checklist de shipping : `docs/superpowers/specs/SHIPPING-CHECKLIST.md`. Scan secrets : **CLEAN** (50 commits audités).

### Méthodo
Chaque phase : plan → **plan-check** (plusieurs blockers réels attrapés & corrigés) → exécution (commits atomiques) → vérification. Tests isolés (jamais le vrai `~/.claude`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
