### PR TITLE
Remise d'équerre du suivi : le ROADMAP reçoit la checklist que le moteur lit

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,8 +8,57 @@
 - ✅ **memory-swarm-rnd** — Phase 9 — R&D : transposition du modèle mémoire + patterns swarm de jcode — spike GO, shippé `v2.28.0` (ADR-052 mémoire vivante + ADR-053 swarm)
 - ✅ **gsd-migration** — Phases 10-11 — clos 2026-07-26, release `v2.39.0` — migration du package GSD `get-shit-done-cc` → `@opengsd/gsd-core@^1` (VOC-02)
 - ✅ **vf-routing** — Phases 12-14 — clos 2026-07-26, release `v2.37.0` — routage fin des intentions (verbes `/vf-*` à l'origine ; carte d'intention agentique depuis la bascule v2.33.0), couverture complète des skills GSD, pont spec → feuille de route, et frontière d'altitude avec le moteur de planning GSD
+- 🚧 **gsd-alignement** — Phases 23-25 — **ouvert le 2026-08-01**, aucune phase démarrée — couplage explicite au moteur GSD, activation des capacités dormantes, budget d'instructions
+
+> **Origine des Phases 23 à 25, dite franchement.** Elles ont été inscrites au ROADMAP le
+> 2026-07-31 par une session concurrente, **hors du périmètre confié** à la mission qui tournait
+> alors (« fin de Phase 20 + toute la Phase 21 »), et poussées dans la PR #23 sans avoir été
+> commandées. Le contenu a été jugé sérieux et **conservé** sur arbitrage de Samuel le
+> 2026-08-01 ; ce jalon existe pour qu'elles cessent d'être des clandestines rattachées à
+> aucun milestone. Leur ouverture reste soumise au cadrage normal (`gsd-discuss-phase`) —
+> être inscrite au ROADMAP ne vaut pas feu vert d'exécution.
 
 ## Phases
+
+### État des phases — checklist lue par le moteur
+
+> **Ne pas retirer.** C'est la SEULE forme que `@opengsd/gsd-core` lit pour établir qu'une phase
+> est terminée (`roadmap.cjs` → `checkboxPattern`) ; il la coche lui-même à la clôture d'une phase
+> vérifiée. La table `## Progress` plus bas, elle, n'est lue par aucun outil : elle est rédigée
+> pour les humains et les deux doivent rester d'accord.
+>
+> Cette checklist a été posée le 2026-08-01, après coup : le ROADMAP n'en avait jamais eu, si bien
+> que le moteur voyait **zéro** phase terminée et rendait des compteurs faux
+> (`completed_phases: 10`, `current_phase: 19` alors que la 22 était livrée). C'est aussi ce qui
+> rattrape les **20 plans sans SUMMARY** des Phases 11 à 14 : `roadmap.cjs` fait explicitement
+> primer la case cochée sur le disque, « pour les phases terminées avant le tracking GSD, qui
+> n'ont pas les paires PLAN/SUMMARY ». Ces 4 phases sont shippées, chacune avec sa release.
+
+- [x] Phase 1: dev-orchestrator (completed 2026-06-04)
+- [x] Phase 2: Manifeste & résolveur (completed 2026-06-04)
+- [x] Phase 3: Engine scope-aware (completed 2026-06-05)
+- [x] Phase 4: Skill /vibeflow-install + auto-lancement (completed 2026-06-05)
+- [x] Phase 5: Packaging plugin (completed 2026-06-05)
+- [x] Phase 6: dev-orchestrator first-use (completed 2026-06-05)
+- [x] Phase 7: Philosophies de dev (completed 2026-07-07)
+- [x] Phase 8: Consolidation des doublons (completed 2026-07-07)
+- [x] Phase 9: Spike transposition jcode (mémoire + swarm) (completed 2026-07-22)
+- [x] Phase 10: Étude & faisabilité migration GSD (completed 2026-07-26)
+- [x] Phase 11: Intégration migration GSD (completed 2026-07-26)
+- [x] Phase 12: Routage fin & couverture complète des verbes (completed 2026-07-25)
+- [x] Phase 13: Pont spec → feuille de route (completed 2026-07-26)
+- [x] Phase 14: Frontière d'altitude planning-core / moteur GSD (completed 2026-07-25)
+- [x] Phase 15: Collaboration inter-équipes dev ↔ design (completed 2026-07-27)
+- [x] Phase 16: Cloisonnement complet des dispatches d'agents (completed 2026-07-27)
+- [x] Phase 17: Signaux de démarrage du moteur de dev (completed 2026-07-28)
+- [ ] Phase 18: Survie du ledger d'exigences à la clôture de jalon
+- [x] Phase 19: Migration du moteur GSD pilotée par /vf-update (completed 2026-07-28)
+- [x] Phase 20: Fluidité du flux de dev sans perte de qualité (completed 2026-07-31)
+- [x] Phase 21: Alignement du moteur GSD sur gsd-core 1.9.0 (completed 2026-07-31)
+- [x] Phase 22: Hygiène documentaire — doctrine de sortie et captation d'intention (completed 2026-07-31)
+- [ ] Phase 23: Couplage explicite au moteur GSD — capabilities, flags et voie unique
+- [ ] Phase 24: Activation et mesure du moteur GSD — capacités dormantes et faits de runtime
+- [ ] Phase 25: Budget d'instructions et étage d'alignement court
 
 <details>
 <summary>✅ vfdo-v1.0 — Module dev-orchestrator (Phase 1) — SHIPPED 2026-06-04</summary>
@@ -374,7 +423,7 @@ Plans:
 ## Progress
 
 **Execution Order:**
-1 ✅ → 2 ✅ → 3 ✅ → 4 ✅ → 5 ✅ ; 6 ✅ indépendant → 7 ✅ → 8 ✅ ; **9 ✅ (R&D, shippée v2.28.0)** ; **10 🚧 → 11 🚧 (GATE : 11 conditionné au GO de 10)** ; **12 ✅ → 13 ✅ (code complet, release en attente de validation humaine)** ; **14 ✅ (indépendante)** ; **15 ✅ (shippée v2.40.0) → 16 ✅ (shippée v2.41.0)** ; **17 ✅ (indépendante de 16, terminée et vérifiée — release en attente de validation humaine) → 18 inscrite (dépend de 17)** ; **19 ✅ (2026-07-28, ADR-058) → 20 ✅ (mergée dans `main` le 2026-07-31, PR #21, release `v2.44.0`)** — ce merge **satisfait** la dépendance « Phase 20 requise » de 21, 22 et 23 ; **21 🚧 + 22 🚧 en vol (mission `reprise-p21-p22`, ordre libre entre elles — aucun fichier commun)** → **23 inscrite : attend la clôture de 21+22**, périmètre partagé sur `vf-dev-manager.md` / `intent-routing.md` (arbitré le 2026-07-31 : on ne planifie pas contre une base qui bouge ; l'arbitrage des étages de revue écrit par la 21 fait autorité) → **24 inscrite (dépendance doctrinale de 23, aucun fichier commun ; son lot MESURE est déjà rendu)** → **25 inscrite : après 24** (son volet G1 pose un gate sur `plugin/*/agents/*.md`, les fichiers mêmes que M3/`effort:` et A2/`agent_skills` éditent) **et dépendante de 23** (son volet G2 insère un étage dans `discuss → plan`, dont la voie unique d'invocation est arbitrée en 23)
+1 ✅ → 2 ✅ → 3 ✅ → 4 ✅ → 5 ✅ ; 6 ✅ indépendant → 7 ✅ → 8 ✅ ; **9 ✅ (R&D, shippée v2.28.0)** ; **10 🚧 → 11 🚧 (GATE : 11 conditionné au GO de 10)** ; **12 ✅ → 13 ✅ (code complet, release en attente de validation humaine)** ; **14 ✅ (indépendante)** ; **15 ✅ (shippée v2.40.0) → 16 ✅ (shippée v2.41.0)** ; **17 ✅ (indépendante de 16, terminée et vérifiée — release en attente de validation humaine) → 18 inscrite (dépend de 17)** ; **19 ✅ (2026-07-28, ADR-058) → 20 ✅ (mergée dans `main` le 2026-07-31, PR #21, release `v2.44.0`)** — ce merge **satisfait** la dépendance « Phase 20 requise » de 21, 22 et 23 ; **21 ✅ (mergée le 2026-07-31, PR #22, release `v2.45.0`) + 22 ✅ (mergée le 2026-07-31, PR #23)** — les deux livrées par la mission `reprise-p21-p22`, sans fichier commun ; leur clôture **lève la dépendance** de 23 → **23 inscrite**, périmètre partagé sur `vf-dev-manager.md` / `intent-routing.md` (arbitré le 2026-07-31 : on ne planifie pas contre une base qui bouge ; l'arbitrage des étages de revue écrit par la 21 fait autorité) → **24 inscrite (dépendance doctrinale de 23, aucun fichier commun ; son lot MESURE est déjà rendu)** → **25 inscrite : après 24** (son volet G1 pose un gate sur `plugin/*/agents/*.md`, les fichiers mêmes que M3/`effort:` et A2/`agent_skills` éditent) **et dépendante de 23** (son volet G2 insère un étage dans `discuss → plan`, dont la voie unique d'invocation est arbitrée en 23)
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
@@ -398,11 +447,11 @@ Plans:
 | 18. Survie du ledger d'exigences | — | 0/0 | Inscrite — périmètre réduit le 2026-07-28 par `18-STUDY.md`, non planifiée | — |
 | 19. Migration du moteur GSD par /vf-update | — | 3/3 | Complete — 3 plans exécutés, VERIFICATION produite, module `dev-orchestrator` v2.7.0 + `conductor` v1.16.0, ADR-058 | 2026-07-28 |
 | 20. Fluidité du flux de dev sans perte de qualité | — | 7/7 | Complete — **mergée dans `main`** (PR #21, `d549b2d`), release `v2.44.0`, VERIFICATION produite | 2026-07-31 |
-| 21. Alignement du moteur GSD sur gsd-core 1.9.0 | — | 0/0 | En planification — pilotée par la mission `reprise-p21-p22` (verrou de driver actif) | — |
-| 22. Hygiène documentaire — doctrine de sortie | — | 1/3 | En cours — 22-01 livré (3/3 tâches, SUMMARY), 22-02 en exécution, DOCF-01..07 mappés au ledger | — |
-| 23. Couplage explicite au moteur GSD | — | 0/0 | Inscrite — 7 lacunes, sûreté en premier ; **attend la clôture de 21+22** (périmètre partagé sur `vf-dev-manager.md`) | — |
-| 24. Activation et mesure du moteur GSD | — | 0/0 | Inscrite — lot MESURE : M2 **rendu** le 2026-07-31, M1/M3 à instruire ; lot ACTIVATION : 8 items | — |
-| 25. Budget d'instructions et étage d'alignement court | — | 0/0 | Inscrite — G1 (compteur d'instructions dans `check-agents.sh`) après 24 ; G2 (outline court `discuss`→`plan`) dépend de 23 | — |
+| 21. Alignement du moteur GSD sur gsd-core 1.9.0 | — | 5/5 | Complete — **mergée dans `main`** (PR #22, `d89a60e`), release `v2.45.0`, VERIFICATION produite, ADR-061/062/063 | 2026-07-31 |
+| 22. Hygiène documentaire — doctrine de sortie | — | 3/3 | Complete — **mergée dans `main`** (PR #23, `474c3eb`), `dev-orchestrator` v2.9.0 + `design-orchestrator` v1.4.0 | 2026-07-31 |
+| 23. Couplage explicite au moteur GSD | gsd-alignement | 0/0 | Inscrite — 7 lacunes, sûreté en premier ; dépendance 21+22 **levée** (les deux mergées le 2026-07-31) | — |
+| 24. Activation et mesure du moteur GSD | gsd-alignement | 0/0 | Inscrite — lot MESURE : M2 **rendu** le 2026-07-31, M1/M3 à instruire ; lot ACTIVATION : 8 items | — |
+| 25. Budget d'instructions et étage d'alignement court | gsd-alignement | 0/0 | Inscrite — G1 (compteur d'instructions dans `check-agents.sh`) après 24 ; G2 (outline court `discuss`→`plan`) dépend de 23 | — |
 
 ### Phase 15: Collaboration inter-équipes dev ↔ design
 
@@ -1047,7 +1096,7 @@ Plans:
 - [x] 21-02-PLAN.md — Changements 2, 3, 4 : contrat `estimate:`/`actuals:` relayé verbatim, ADR-061 (recouvrement lanes de revue amont vs étage 20-06), hypothèse datée du dispatch nommé + recoupement #1995/#2608 (vague 1)
 - [x] 21-03-PLAN.md — Changements 5, 6 : purge de la dette de version 1.8.0 → 1.9.0, ADR-062 (hooks 1.9.0 non câblés, absence correcte dans les deux cas) (vague 2)
 - [x] 21-04-PLAN.md — Point hérité : `check-state-integrity.sh` (gate anti-régression du frontmatter de `STATE.md`, module `conductor` v1.18.0) et ADR-063 (arbitrage de l'anomalie d'agrégation) (vague 2)
-- [x] 21-05-PLAN.md — Gouvernance : CI remise au vert (compteur de suites), 2 modules bumpés (`dev-orchestrator` v2.10.0 — v2.9.0 prise par la Phase 22, `planning-core` v2.5.3), ROADMAP recalé, 4 warnings traités, `STATE.md` recalé, release racine v2.45.0 préparée (vague 3, dépend de tous)
+- [x] 21-05-PLAN.md — Gouvernance : CI remise au vert (compteur de suites), 2 modules bumpés (`dev-orchestrator` v2.10.0 — v2.9.0 étant déjà prise en amont, `planning-core` v2.5.3), ROADMAP recalé, 4 warnings traités, `STATE.md` recalé, release racine v2.45.0 préparée (vague 3, dépend de tous)
 
 ### Phase 22: Hygiène documentaire — doctrine de sortie et captation d'intention
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,16 +3,16 @@ gsd_state_version: 1.0
 milestone: gsd-migration
 milestone_name: Migration package GSD
 current_phase: 22
-current_phase_name: Hygiène documentaire — doctrine de sortie et captation d'intention (Phase 22 mergée) ; Phase 21 close, release v2.45.0 préparée (non taguée)
+current_phase_name: Phases 21 et 22 mergées et shippées ; ROADMAP et compteurs remis d'équerre le 2026-08-01
 status: complete
 stopped_at: "Phase 21 close par sa gouvernance (plan 21-05), même patron que 20-07/c01f813 : 5/5 plans livrés, vérification PASS PARTIEL 7/8 comblée (CI remise au vert — compteur de suites 44→45 —, dev-orchestrator bumpé v2.9.0, planning-core v2.5.3, ROADMAP §Phase 21 recalé, 4 warnings W1-W4 traités : check-state-integrity.sh câblé au job gates de la CI, ADR-063 23→25 cas, team-kernel.md porte le recoupement #1995/#2608, inject-mcp-tools.sh nomme --force sur le rc=3 mode fichier unique). Release racine v2.45.0 préparée en commits locaux (triade + 2 historiques README + CHANGELOG racine) — AUCUN tag, AUCUN merge, AUCUN push : réservés à Samuel. Prochain geste humain : merger la PR, puis `git tag -a v2.45.0` et `gh release create`."
 last_updated: "2026-07-31T19:30:00.000Z"
 last_activity: 2026-07-31 (Phase 21 plan 21-05 — clôture de gouvernance, release v2.45.0 préparée)
 progress:
   total_phases: 25
-  completed_phases: 14
-  total_plans: 59
-  completed_plans: 44
+  completed_phases: 21
+  total_plans: 62
+  completed_plans: 62
 # ⚠ Compteurs curés À LA MAIN — PAS régénérés par `gsd-tools state` (ADR-063, cf.
 # plugin/dev-orchestrator/references/mission-contracts.md §STATE.md : toute invocation force
 # resync:true non désactivable et reproduirait la régression corrigée ici). Toute future mise à
@@ -22,6 +22,10 @@ progress:
 # ayant été mergée AVANT la #22, ces compteurs cumulent les deux phases — +1 phase complète
 # (22) et +3 plans livrés (22-01..03), et total_phases passe à 25 (phases 23/24/25 inscrites au
 # ROADMAP par la Phase 22, hors périmètre, en attente d'arbitrage).
+# ⚠ Recompté le 2026-08-01 depuis le disque ET la checklist du ROADMAP, une fois celle-ci posée
+# (elle n'avait jamais existé : le moteur voyait 0 phase terminée). 21 phases complètes sur 25
+# — les 4 restantes (18, 23, 24, 25) sont inscrites sans aucun plan. 62 PLAN.md sur disque, tous
+# rattachés à une phase complète, d'où completed_plans = total_plans.
 #
 # Baseline héritée telle quelle (12/54/39), recalée le 2026-07-31 lors de la clôture 20-07 après une
 # régression constatée (completed_phases 11→10, total_plans 53→49, completed_plans 37→29,

--- a/.planning/missions/dag-reprise-p21-p22.json
+++ b/.planning/missions/dag-reprise-p21-p22.json
@@ -48,7 +48,7 @@
         "p21:VERSION",
         "p21:README"
       ],
-      "status": "running"
+      "status": "done"
     },
     {
       "id": "p21-pr",
@@ -58,7 +58,7 @@
         "p21-verif"
       ],
       "scope": [],
-      "status": "blocked"
+      "status": "done"
     },
     {
       "id": "p22-exec-02",
@@ -83,7 +83,7 @@
         "main:plugin/dev-orchestrator/",
         "main:plugin/conductor/"
       ],
-      "status": "running"
+      "status": "done"
     },
     {
       "id": "p22-verif",
@@ -95,7 +95,7 @@
       "scope": [
         "main:.planning/"
       ],
-      "status": "blocked"
+      "status": "done"
     },
     {
       "id": "p22-pr",
@@ -105,7 +105,7 @@
         "p22-verif"
       ],
       "scope": [],
-      "status": "blocked"
+      "status": "done"
     }
   ]
 }

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -1354,9 +1354,20 @@ contrôle de VibeFlow, même patron que la RFC de la Phase 18)** :
    `SUMMARY.md` (missions d'équipe, cadrage allégé) voit ses compteurs régresser à chaque écriture
    d'état, sans qu'aucun signal ne le prévienne.
 
-Le texte des deux signalements est rédigé dans `.planning/missions/2026-07-31-delta-gsd-core-1.9.0.md`
-(section à compléter par le dépôt effectif) — **le dépôt lui-même (issue ou PR sur
-`github.com/open-gsd/gsd-core`) reste une action humaine**, cette ADR ne prétend pas l'avoir fait.
+**Déposés le 2026-08-01**, sur accord de Samuel : point 1 → [open-gsd/gsd-core#2956](https://github.com/open-gsd/gsd-core/issues/2956),
+point 2 → [#2957](https://github.com/open-gsd/gsd-core/issues/2957), croisées l'une vers l'autre.
+
+La recherche préalable a affiné le point 1 : le défaut a une **lignée établie** en amont —
+[#2444](https://github.com/open-gsd/gsd-core/issues/2444) a scopé `Stopped At`,
+[#2567](https://github.com/open-gsd/gsd-core/issues/2567) a signalé que les champs frères restaient
+exposés. `Last Activity` a alors reçu un garde-fou propre (`preferNewerLastActivity`, sur la
+direction de date plutôt que sur la section — son commentaire dit pourquoi : il n'a pas de section
+canonique). **`Phase` n'a rien reçu**, alors qu'il vit, lui, dans une section canonique : le
+correctif de #2444 s'y applique tel quel. C'est l'argument porté par #2956.
+
+Le point 2 a été porté plus haut que « il manque un repli » : `buildStateFrontmatter` lit le
+ROADMAP pour le **dénominateur** (`Math.max(phaseDirs.length, roadmapPhaseCount)`) et refuse de le
+lire pour le **numérateur** — ce qui désigne un oubli, pas un choix de conception.
 
 **Sur le backfill des `SUMMARY.md` manquants (Phases 11/12/13/14)** : **non tranché ici,
 explicitement remonté à Samuel.** Deux options restent ouvertes — (a) backfiller rétroactivement


### PR DESCRIPTION
## Le problème, plus large que prévu

Le chantier était annoncé comme « les ~20 SUMMARY manquants ». Le diagnostic GSD (`gsd-progress`, `roadmap.analyze`) a montré autre chose : **le ROADMAP n'avait jamais porté la checklist de phases**, seule forme que `@opengsd/gsd-core` lit pour établir qu'une phase est terminée (`roadmap.cjs` → `checkboxPattern`).

Conséquence : le moteur voyait **zéro** phase terminée — `roadmap_complete: false` sur les 24 — et rendait des compteurs faux (`completed_phases: 10`, `current_phase: 19` alors que la Phase 22 était livrée et mergée). La table `## Progress`, riche et tenue à jour, n'est lue par aucun outil : elle est écrite pour les humains. Les deux se sont éloignées sans que rien ne le signale.

## Ce que fait cette PR

**La checklist est posée** pour les 25 phases, d'après l'état réel. Vérifié après coup par le moteur : **20 phases complètes sur 24 vues, `next: 18`**.

**Les 20 plans sans SUMMARY (Phases 11 à 14) sont réglés du même geste**, sans qu'un seul fichier soit fabriqué. `roadmap.cjs:351` fait explicitement primer la case cochée sur le disque, *« pour les phases terminées avant le tracking GSD, qui n'ont pas les paires PLAN/SUMMARY »*. Ces 4 phases sont shippées, chacune avec sa release (`v2.39.0`, `v2.31.0`, `v2.37.0`, `v2.30.0`). Arbitrage de Samuel : mécanisme officiel plutôt que backfill rétroactif — reconstituer 20 SUMMARY a posteriori aurait produit du contenu déduit, pas vécu.

**Les Phases 23, 24 et 25 sont régularisées** plutôt que retirées. Elles avaient été inscrites hors périmètre par une session concurrente et ne se rattachaient à aucun jalon. Nouveau jalon `gsd-alignement`, dépendances déclarées, et une note d'origine qui dit franchement d'où elles viennent — avec le rappel qu'être inscrite au ROADMAP ne vaut pas feu vert d'exécution.

**Aussi** : table `## Progress` recalée (21 → 5/5, 22 → 3/3 Complete), ordre d'exécution mis à jour (la dépendance de 23 est levée par le merge des deux), `STATE.md` recompté à la main comme l'exige ADR-063 (21/25 phases, 62 plans), et un faux positif tué — une ligne de plan citait « la Phase 22 » assez près d'une case cochée pour risquer d'être lue comme sa checklist.

## Les deux signalements amont sont déposés

- [open-gsd/gsd-core#2956](https://github.com/open-gsd/gsd-core/issues/2956) — `Phase` toujours non scopé dans `buildStateFrontmatter`. La recherche a établi une **lignée** : #2444 a scopé `Stopped At`, #2567 a signalé que les champs frères restaient exposés, `Last Activity` a reçu son garde-fou, `Phase` n'a rien reçu — alors qu'il vit dans une section canonique.
- [#2957](https://github.com/open-gsd/gsd-core/issues/2957) — `buildStateFrontmatter` ignore la checkbox que `roadmap.analyze` honore délibérément. La même fonction lit le ROADMAP pour le dénominateur et refuse de le lire pour le numérateur.

ADR-063 les référence désormais par leur numéro, à la place du « à déposer » qui y figurait.

## Gates

- `check-state-integrity.sh` ✓ (compteurs non régressés, 1 ligne `^Phase:`)
- `roadmap validate` — 0 warning
- `check-mission-invariants.sh` → exit 3 (SAIN)
- `check-version-sync.sh` ✓ · `check-release-tag.sh --remote` ✓
- Aucun code applicatif touché : cette PR ne modifie que `.planning/` et `docs/ADR.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9V7m8pEqkgbWjJ7DuvkA7